### PR TITLE
chore: downgrade version to what is actually released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "klag-exporter"
-version = "0.1.8"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klag-exporter"
-version = "0.1.8"
+version = "0.1.7"
 edition = "2021"
 description = "High-performance Kafka consumer group lag exporter with offset and time lag metrics"
 authors = ["Krzysztof Grajek"]


### PR DESCRIPTION
It's here as I bumped the version assuming we will do manual release, but now we have release-plz - let's fix the version to what is actually released, so the automation could do the job.