### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/softwaremill/klag-exporter/compare/v0.1.8...v0.1.9) - 2026-01-16
+
+### Other
+
+- release v0.1.8 ([#14](https://github.com/softwaremill/klag-exporter/pull/14))
+- add release-plz configuration, move the release job to "on pr merge" ([#13](https://github.com/softwaremill/klag-exporter/pull/13))
+- downgrade version to what is actually released ([#12](https://github.com/softwaremill/klag-exporter/pull/12))
+
 ## [0.1.8](https://github.com/softwaremill/klag-exporter/compare/v0.1.7...v0.1.8) - 2026-01-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "klag-exporter"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klag-exporter"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "High-performance Kafka consumer group lag exporter with offset and time lag metrics"
 authors = ["Krzysztof Grajek"]


### PR DESCRIPTION



## 🤖 New release

* `klag-exporter`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/softwaremill/klag-exporter/compare/v0.1.8...v0.1.9) - 2026-01-16

### Other

- release v0.1.8 ([#14](https://github.com/softwaremill/klag-exporter/pull/14))
- add release-plz configuration, move the release job to "on pr merge" ([#13](https://github.com/softwaremill/klag-exporter/pull/13))
- downgrade version to what is actually released ([#12](https://github.com/softwaremill/klag-exporter/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).