### PR TITLE
docs: add group_state metric to metrics tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Use `${VAR_NAME}` syntax in config values. The exporter will substitute with env
 | `kafka_consumergroup_group_max_lag_seconds` | cluster_name, group        | Max time lag across partitions   |
 | `kafka_consumergroup_group_sum_lag`         | cluster_name, group        | Sum of offset lag                |
 | `kafka_consumergroup_group_topic_sum_lag`   | cluster_name, group, topic | Sum of offset lag per topic      |
+| `kafka_consumergroup_group_state`          | cluster_name, group        | Consumer group state as integer (0=Unknown, 1=PreparingRebalance, 2=CompletingRebalance, 3=Stable, 4=Dead, 5=Empty, 6=Assigning, 7=Reconciling) |
 
 ### Operational Metrics
 

--- a/docs/metrics-collection.md
+++ b/docs/metrics-collection.md
@@ -201,6 +201,7 @@ datacenter = "us-east-1"
 | `kafka_consumergroup_group_sum_lag` | Sum of lag across all partitions | cluster_name, group |
 | `kafka_consumergroup_group_max_lag` | Max offset lag across partitions | cluster_name, group |
 | `kafka_consumergroup_group_max_lag_seconds` | Max time lag across partitions | cluster_name, group |
+| `kafka_consumergroup_group_state` | Consumer group state as integer (0=Unknown, 1=PreparingRebalance, 2=CompletingRebalance, 3=Stable, 4=Dead, 5=Empty, 6=Assigning, 7=Reconciling) | cluster_name, group |
 
 ### Topic-Level Metrics
 


### PR DESCRIPTION
## Summary

- Add `kafka_consumergroup_group_state` metric to README.md and docs/metrics-collection.md metrics tables
- Follow-up to #51

## Test plan

- Documentation-only change, no code affected