### PR TITLE
fix(grafana): widen Topic Message Rate window to [5m]

### DIFF
--- a/test-stack/grafana/provisioning/dashboards/kafka-lag.json
+++ b/test-stack/grafana/provisioning/dashboards/kafka-lag.json
@@ -1181,7 +1181,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (topic) (rate(kafka_partition_latest_offset{cluster_name=~\"$cluster\", topic=~\"$topic\"}[1m]))",
+          "expr": "sum by (topic) (rate(kafka_partition_latest_offset{cluster_name=~\"$cluster\", topic=~\"$topic\"}[5m]))",
           "legendFormat": "{{topic}} (produced)",
           "refId": "A"
         },
@@ -1190,7 +1190,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (group, topic) (rate(kafka_consumergroup_group_offset{cluster_name=~\"$cluster\", group=~\"$consumer_group\", topic=~\"$topic\"}[1m]))",
+          "expr": "sum by (group, topic) (rate(kafka_consumergroup_group_offset{cluster_name=~\"$cluster\", group=~\"$consumer_group\", topic=~\"$topic\"}[5m]))",
           "legendFormat": "{{group}} - {{topic}} (consumed)",
           "refId": "B"
         }


### PR DESCRIPTION
## Summary
- Fixes #64 — the "Topic Message Rate (msg/sec)" panel in the example dashboard renders empty with typical production Prometheus scrape intervals.
- Root cause: `rate(...[1m])` requires ≥ 2 samples in the window, so it only works when `scrape_interval <= 15s`. The test-stack scrapes at 10s, which is why the demo looked fine, but 30s/60s scrape intervals give 0–1 samples → "No data".
- Fix: widened both queries in the panel to `[5m]`. Same formula, longer window — keeps `msg/sec` units correct and works for scrape intervals up to ~75s.

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`)
- [x] Verified locally in the test-stack: dashboard panel shows produced/consumed rates after ~5min of traffic.
- [ ] Reviewer: to reproduce the original bug, bump `test-stack/prometheus/prometheus.yml` `scrape_interval` to `60s`, restart Prometheus, and confirm the old `[1m]` query returns empty while the new `[5m]` query returns values.
