### PR TITLE
perf: batched Admin API — eliminate large-cluster collection timeout (Tier 1, addresses #61)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 # Install build dependencies for rdkafka
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -485,13 +485,20 @@ To calculate accurate time lag, klag-exporter fetches messages from Kafka® at t
 
 ## Large Cluster Configuration
 
-When monitoring large Kafka clusters with hundreds of consumer groups or thousands of partitions, the default settings may cause collection timeouts. The exporter includes performance tuning options to handle scale effectively.
+klag-exporter uses librdkafka's **batched Admin API** for its collection hot path. Per collection cycle it makes approximately:
+
+- **2** batched `ListOffsets` calls (one EARLIEST, one LATEST) regardless of partition count — librdkafka routes per leader broker internally, so on a 3-broker cluster this is ~6 broker RPCs even for 20,000 partitions
+- **`ceil(groups / 100)`** batched `DescribeConsumerGroups` calls (currently a single chunked call up to 100 groups at a time)
+- **one `ListConsumerGroupOffsets` call per group**, fanned out with `max_concurrent_groups` concurrency. Each call passes `NULL` partitions, so the broker returns only the committed partitions for that group — no client-side 19K-partition list is sent. *(librdkafka 2.12 enforces one group per call here; once that restriction is lifted, call count drops further.)*
+- **one `DescribeConfigs`** restricted to the monitored topic set (topics surviving the whitelist/blacklist), for compacted-topic detection
+
+Topic whitelist/blacklist is applied **before** any partition-touching call, so `__consumer_offsets` (50 partitions by default) and blacklisted topics are excluded from the hot path entirely.
 
 ### Symptoms of Scale Issues
 
 - `Collection timed out` errors in logs
-- `Failed to fetch committed offsets` with `OperationTimedOut` errors
 - Collection cycles consistently exceeding the poll interval
+- RSS climbing cycle over cycle
 
 ### Performance Tuning Options
 
@@ -499,32 +506,36 @@ Add the `[exporter.performance]` section to tune parallelism and timeouts:
 
 ```toml
 [exporter]
-poll_interval = "60s"  # Increase for large clusters
+poll_interval = "60s"  # Increase for very large clusters if needed
 
 [exporter.performance]
 # Timeout for individual Kafka API operations (metadata, watermarks)
-kafka_timeout = "15s"           # Default: 30s
+kafka_timeout = "30s"            # Default: 30s
 
-# Timeout for fetching committed offsets per consumer group
-offset_fetch_timeout = "5s"     # Default: 10s
+# Timeout for each per-group committed-offsets fetch
+offset_fetch_timeout = "10s"     # Default: 10s
 
-# Maximum consumer groups to fetch offsets for in parallel
-max_concurrent_groups = 20      # Default: 10
+# Parallel in-flight ListConsumerGroupOffsets calls (one group per call).
+# Increase on large clusters so a backlog of groups drains quickly.
+max_concurrent_groups = 30       # Default: 10
 
-# Maximum partitions to fetch watermarks for in parallel
-max_concurrent_watermarks = 100 # Default: 50
+# Legacy — no longer affects the hot path after the Tier 1 batched Admin
+# API refactor (watermarks now come from one batched ListOffsets per
+# broker), but still honored for compatibility.
+max_concurrent_watermarks = 50   # Default: 50
 
 # Client recycling interval — see Memory Management section below
-client_recycle_interval = 50    # Default: 50 (set 0 to disable)
+client_recycle_interval = 50     # Default: 50 (set 0 to disable)
 ```
 
 ### Recommended Settings by Cluster Size
 
-| Cluster Size | Groups | Partitions | poll_interval | max_concurrent_groups | max_concurrent_watermarks |
-|--------------|--------|------------|---------------|----------------------|---------------------------|
-| Small        | < 50   | < 500      | 30s           | 10 (default)         | 50 (default)              |
-| Medium       | 50-200 | 500-2000   | 60s           | 20                   | 100                       |
-| Large        | > 200  | > 2000     | 120s          | 30                   | 200                       |
+| Cluster Size | Groups | Partitions | poll_interval | max_concurrent_groups |
+|--------------|--------|------------|---------------|------------------------|
+| Small        | < 50   | < 500      | 30s           | 10 (default)           |
+| Medium       | 50-200 | 500-2000   | 60s           | 20                     |
+| Large        | 200–1000 | 2000–20000 | 60–120s | 30                     |
+| Very large   | > 1000 | > 20000    | 120–180s      | 50                     |
 
 ### Additional Recommendations for Large Clusters
 

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -255,13 +255,12 @@ impl ClusterManager {
 
         // Collect offsets, watermarks, and compacted-topic set in one batched pass.
         let snapshot = self.offset_collector.collect_parallel().await?;
-        let compacted_topics = snapshot.compacted_topics.clone();
 
         debug!(
             cluster = %self.cluster_name,
             groups = snapshot.groups.len(),
             partitions = snapshot.watermarks.len(),
-            compacted_topics = compacted_topics.len(),
+            compacted_topics = snapshot.compacted_topics.len(),
             "Collected offsets"
         );
 
@@ -284,7 +283,7 @@ impl ClusterManager {
             &timestamps,
             now_ms,
             poll_time_ms,
-            &compacted_topics,
+            &snapshot.compacted_topics,
         );
 
         // Update registry with granularity and custom labels

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -253,37 +253,17 @@ impl ClusterManager {
     async fn collect_once(&self) -> Result<()> {
         let start = Instant::now();
 
-        // Collect offsets using parallel method for better performance with large clusters
+        // Collect offsets, watermarks, and compacted-topic set in one batched pass.
         let snapshot = self.offset_collector.collect_parallel().await?;
+        let compacted_topics = snapshot.compacted_topics.clone();
 
         debug!(
             cluster = %self.cluster_name,
             groups = snapshot.groups.len(),
             partitions = snapshot.watermarks.len(),
+            compacted_topics = compacted_topics.len(),
             "Collected offsets"
         );
-
-        // Fetch compacted topics (topics with cleanup.policy=compact)
-        let compacted_topics = match self.client.fetch_compacted_topics().await {
-            Ok(topics) => {
-                if !topics.is_empty() {
-                    debug!(
-                        cluster = %self.cluster_name,
-                        compacted_topics = ?topics,
-                        "Identified compacted topics"
-                    );
-                }
-                topics
-            }
-            Err(e) => {
-                warn!(
-                    cluster = %self.cluster_name,
-                    error = %e,
-                    "Failed to fetch topic configs, assuming no compacted topics"
-                );
-                HashSet::new()
-            }
-        };
 
         // Collect timestamps if enabled (with concurrency limit)
         let timestamps = if let Some(ref sampler) = self.timestamp_sampler {

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -8,7 +8,7 @@ use crate::kafka::TimestampConsumer;
 use crate::leadership::LeadershipStatus;
 use crate::metrics::registry::MetricsRegistry;
 use futures::future::join_all;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -338,6 +338,7 @@ mod tests {
                 offsets,
             }],
             watermarks,
+            compacted_topics: HashSet::new(),
             timestamp_ms: 1000000,
         }
     }
@@ -420,6 +421,7 @@ mod tests {
                 offsets,
             }],
             watermarks,
+            compacted_topics: HashSet::new(),
             timestamp_ms: 0,
         };
 

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -43,18 +43,6 @@ pub struct MemberSnapshot {
 }
 
 impl OffsetCollector {
-    /// Create a new OffsetCollector with default performance config.
-    /// Prefer `with_performance` for large clusters.
-    #[allow(dead_code)]
-    pub fn new(client: Arc<KafkaClient>, filters: CompiledFilters) -> Self {
-        let performance = client.performance().clone();
-        Self {
-            client,
-            filters,
-            performance,
-        }
-    }
-
     pub fn with_performance(
         client: Arc<KafkaClient>,
         filters: CompiledFilters,
@@ -65,94 +53,6 @@ impl OffsetCollector {
             filters,
             performance,
         }
-    }
-
-    /// Collect offsets sequentially (legacy method).
-    /// For large clusters, use `collect_parallel` instead.
-    #[allow(dead_code)]
-    #[instrument(skip(self), fields(cluster = %self.client.cluster_name()))]
-    pub fn collect(&self) -> Result<OffsetsSnapshot> {
-        let start = std::time::Instant::now();
-
-        // List all consumer groups
-        let all_groups = self.client.list_consumer_groups()?;
-        debug!(
-            total_groups = all_groups.len(),
-            "Listed all consumer groups"
-        );
-
-        // Filter groups
-        let filtered_groups: Vec<_> = all_groups
-            .iter()
-            .filter(|g| self.filters.matches_group(&g.group_id))
-            .collect();
-        debug!(
-            filtered_groups = filtered_groups.len(),
-            "Filtered consumer groups"
-        );
-
-        // Get group descriptions
-        let group_ids: Vec<&str> = filtered_groups
-            .iter()
-            .map(|g| g.group_id.as_str())
-            .collect();
-        let descriptions = self.client.describe_consumer_groups(&group_ids)?;
-
-        // Fetch watermarks for all topics
-        let watermarks = self.client.fetch_all_watermarks()?;
-        debug!(partitions = watermarks.len(), "Fetched watermarks");
-
-        // Build group snapshots
-        let wm_keys: Vec<TopicPartition> = watermarks.keys().cloned().collect();
-        let mut groups = Vec::with_capacity(descriptions.len());
-        for desc in descriptions {
-            let offsets = self.client.list_consumer_group_offsets(
-                &desc.group_id,
-                &wm_keys,
-                self.performance.offset_fetch_timeout,
-            )?;
-
-            // Filter offsets by topic whitelist/blacklist
-            let filtered_offsets: HashMap<TopicPartition, i64> = offsets
-                .into_iter()
-                .filter(|(tp, _)| self.filters.matches_topic(&tp.topic))
-                .collect();
-
-            let members = desc
-                .members
-                .into_iter()
-                .map(|m| MemberSnapshot {
-                    member_id: m.member_id,
-                    client_id: m.client_id,
-                    client_host: m.client_host,
-                    assignments: m.assignments,
-                })
-                .collect();
-
-            groups.push(GroupSnapshot {
-                group_id: desc.group_id,
-                state: desc.state,
-                members,
-                offsets: filtered_offsets,
-            });
-        }
-
-        // Filter watermarks by topic
-        let filtered_watermarks: HashMap<TopicPartition, (i64, i64)> = watermarks
-            .into_iter()
-            .filter(|(tp, _)| self.filters.matches_topic(&tp.topic))
-            .collect();
-
-        let elapsed = start.elapsed();
-        debug!(elapsed_ms = elapsed.as_millis(), "Collection completed");
-
-        Ok(OffsetsSnapshot {
-            cluster_name: self.client.cluster_name().to_string(),
-            groups,
-            watermarks: filtered_watermarks,
-            compacted_topics: HashSet::new(),
-            timestamp_ms: chrono_timestamp_ms(),
-        })
     }
 
     /// Collect offsets using batched Admin API calls. Drives everything from a
@@ -209,7 +109,9 @@ impl OffsetCollector {
             let parts = monitored_partitions.clone();
             tokio::task::spawn_blocking(move || client.fetch_watermarks_for_partitions(&parts))
                 .await
-                .map_err(|e| crate::error::KlagError::Admin(format!("watermark task panicked: {e}")))??
+                .map_err(|e| {
+                    crate::error::KlagError::Admin(format!("watermark task panicked: {e}"))
+                })??
         };
         debug!(
             partitions = watermarks.len(),

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -59,10 +59,16 @@ impl OffsetCollector {
     /// single filtered topic-set so internal / blacklisted topics never enter
     /// the watermark + compacted-topic-config path.
     ///
-    /// Per-cycle RPC count is O(brokers + groups/chunk_size) — two
-    /// batched ListOffsets calls (EARLIEST + LATEST) plus one batched
-    /// DescribeConsumerGroups plus `ceil(groups/100)` batched
-    /// ListConsumerGroupOffsets calls, regardless of topic/partition count.
+    /// Per-cycle RPC count:
+    ///   - 2 batched ListOffsets calls (EARLIEST + LATEST), routed per leader
+    ///     broker internally — O(brokers) broker round trips regardless of
+    ///     partition count.
+    ///   - `ceil(groups / 100)` batched DescribeConsumerGroups calls.
+    ///   - 1 ListConsumerGroupOffsets call per group (`PER_CALL_CHUNK = 1`
+    ///     in `fetch_all_group_offsets_batched` because librdkafka 2.12
+    ///     rejects multi-group calls at the client layer; fanned out via
+    ///     `max_concurrent_groups`).
+    ///   - 1 DescribeConfigs call restricted to monitored topics.
     #[instrument(skip(self), fields(cluster = %self.client.cluster_name()))]
     pub async fn collect_parallel(&self) -> Result<OffsetsSnapshot> {
         let start = std::time::Instant::now();
@@ -103,15 +109,19 @@ impl OffsetCollector {
             "Computed monitored topic + partition set"
         );
 
-        // Watermarks via batched ListOffsets (two blocking FFI calls).
+        // Watermarks via batched ListOffsets (two blocking FFI calls). Move
+        // `monitored_partitions` into the blocking closure — no subsequent
+        // use in this function, and cloning an O(partitions) Vec every cycle
+        // is wasted work on large clusters.
         let watermarks = {
             let client = Arc::clone(&self.client);
-            let parts = monitored_partitions.clone();
-            tokio::task::spawn_blocking(move || client.fetch_watermarks_for_partitions(&parts))
-                .await
-                .map_err(|e| {
-                    crate::error::KlagError::Admin(format!("watermark task panicked: {e}"))
-                })??
+            tokio::task::spawn_blocking(move || {
+                client.fetch_watermarks_for_partitions(&monitored_partitions)
+            })
+            .await
+            .map_err(|e| {
+                crate::error::KlagError::Admin(format!("watermark task panicked: {e}"))
+            })??
         };
         debug!(
             partitions = watermarks.len(),
@@ -252,15 +262,21 @@ impl OffsetCollector {
             handles.push(tokio::spawn(async move {
                 let _permit: OwnedSemaphorePermit =
                     permit.acquire_owned().await.expect("semaphore closed");
-                tokio::task::spawn_blocking(move || {
-                    list_consumer_group_offsets_batched(
-                        &client_clone.admin_handle(),
-                        &[gid.as_str()],
-                        offset_timeout,
-                        PER_CALL_CHUNK,
-                    )
+                // Return the group id alongside the result so failure logs
+                // can report which group broke.
+                let result = tokio::task::spawn_blocking({
+                    let gid = gid.clone();
+                    move || {
+                        list_consumer_group_offsets_batched(
+                            &client_clone.admin_handle(),
+                            &[gid.as_str()],
+                            offset_timeout,
+                            PER_CALL_CHUNK,
+                        )
+                    }
                 })
-                .await
+                .await;
+                (gid, result)
             }));
         }
 
@@ -269,9 +285,13 @@ impl OffsetCollector {
         let mut merged: HashMap<String, HashMap<TopicPartition, i64>> = HashMap::new();
         for r in results {
             match r {
-                Ok(Ok(Ok(map))) => merged.extend(map),
-                Ok(Ok(Err(e))) => warn!(error = %e, "Group-offset call failed"),
-                Ok(Err(e)) => warn!(error = %e, "Group-offset call task panicked"),
+                Ok((_gid, Ok(Ok(map)))) => merged.extend(map),
+                Ok((gid, Ok(Err(e)))) => {
+                    warn!(group = %gid, error = %e, "Group-offset call failed")
+                }
+                Ok((gid, Err(e))) => {
+                    warn!(group = %gid, error = %e, "Group-offset call task panicked")
+                }
                 Err(e) => warn!(error = %e, "Group-offset join error"),
             }
         }

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -1,7 +1,7 @@
 use crate::config::{CompiledFilters, PerformanceConfig};
 use crate::error::Result;
 use crate::kafka::client::{KafkaClient, TopicPartition};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, instrument, warn};
@@ -17,6 +17,11 @@ pub struct OffsetsSnapshot {
     pub cluster_name: String,
     pub groups: Vec<GroupSnapshot>,
     pub watermarks: HashMap<TopicPartition, (i64, i64)>,
+    /// Topics configured with `cleanup.policy=compact`. Populated by
+    /// `collect_parallel` for the monitored topic set. Used by the lag
+    /// calculator to suppress data-loss warnings on compacted topics (where
+    /// low_watermark ahead of committed_offset is expected, not a loss).
+    pub compacted_topics: HashSet<String>,
     #[allow(dead_code)]
     pub timestamp_ms: i64,
 }
@@ -145,24 +150,30 @@ impl OffsetCollector {
             cluster_name: self.client.cluster_name().to_string(),
             groups,
             watermarks: filtered_watermarks,
+            compacted_topics: HashSet::new(),
             timestamp_ms: chrono_timestamp_ms(),
         })
     }
 
-    /// Collect offsets with parallel watermark and group offset fetching.
-    /// This is more efficient for large clusters with many groups and partitions.
+    /// Collect offsets using batched Admin API calls. Drives everything from a
+    /// single filtered topic-set so internal / blacklisted topics never enter
+    /// the watermark + compacted-topic-config path.
+    ///
+    /// Per-cycle RPC count is O(brokers + groups/chunk_size) — two
+    /// batched ListOffsets calls (EARLIEST + LATEST) plus one batched
+    /// DescribeConsumerGroups plus `ceil(groups/100)` batched
+    /// ListConsumerGroupOffsets calls, regardless of topic/partition count.
     #[instrument(skip(self), fields(cluster = %self.client.cluster_name()))]
     pub async fn collect_parallel(&self) -> Result<OffsetsSnapshot> {
         let start = std::time::Instant::now();
 
-        // List all consumer groups (single call, cannot parallelize)
+        // List all consumer groups (single metadata call).
         let all_groups = self.client.list_consumer_groups()?;
         debug!(
             total_groups = all_groups.len(),
             "Listed all consumer groups"
         );
 
-        // Filter groups
         let filtered_groups: Vec<_> = all_groups
             .iter()
             .filter(|g| self.filters.matches_group(&g.group_id))
@@ -172,24 +183,54 @@ impl OffsetCollector {
             "Filtered consumer groups"
         );
 
-        // Get group descriptions (still sequential as this is a metadata call)
         let group_ids: Vec<&str> = filtered_groups
             .iter()
             .map(|g| g.group_id.as_str())
             .collect();
+
+        // Describe filtered groups via batched FFI (one chunked call).
         let descriptions = self.client.describe_consumer_groups(&group_ids)?;
 
-        // Fetch watermarks in parallel
-        let watermarks = self.client.fetch_all_watermarks_parallel().await?;
+        // Compute the monitored partition + topic set once from a single
+        // metadata fetch. Topic filter is applied here, BEFORE any
+        // partition-touching operation — this keeps `__consumer_offsets`
+        // (50 partitions by default) and blacklisted topics out of the hot
+        // path entirely.
+        let (monitored_partitions, monitored_topics) = self.list_monitored_partitions()?;
         debug!(
-            partitions = watermarks.len(),
-            "Fetched watermarks (parallel)"
+            partitions = monitored_partitions.len(),
+            topics = monitored_topics.len(),
+            "Computed monitored topic + partition set"
         );
 
-        // Fetch group offsets in parallel
-        let group_offsets = self
-            .fetch_all_group_offsets_parallel(&descriptions, &watermarks)
-            .await;
+        // Watermarks via batched ListOffsets (two blocking FFI calls).
+        let watermarks = {
+            let client = Arc::clone(&self.client);
+            let parts = monitored_partitions.clone();
+            tokio::task::spawn_blocking(move || client.fetch_watermarks_for_partitions(&parts))
+                .await
+                .map_err(|e| crate::error::KlagError::Admin(format!("watermark task panicked: {e}")))??
+        };
+        debug!(
+            partitions = watermarks.len(),
+            "Fetched watermarks (batched)"
+        );
+
+        // Group offsets via batched multi-group ListConsumerGroupOffsets.
+        // `NULL` partitions → broker returns every committed partition per
+        // group; we then filter the (much smaller) response by topic.
+        let group_offsets = self.fetch_all_group_offsets_batched(&group_ids).await;
+
+        // Compacted-topic lookup restricted to monitored topics (huge saving
+        // vs. the prior full-cluster DescribeConfigs).
+        let compacted_topics = self
+            .client
+            .fetch_compacted_topics_for(&monitored_topics)
+            .await
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "Failed to fetch compacted topics");
+                HashSet::new()
+            });
 
         // Build group snapshots
         let mut groups = Vec::with_capacity(descriptions.len());
@@ -199,7 +240,6 @@ impl OffsetCollector {
                 .cloned()
                 .unwrap_or_default();
 
-            // Filter offsets by topic whitelist/blacklist
             let filtered_offsets: HashMap<TopicPartition, i64> = offsets
                 .into_iter()
                 .filter(|(tp, _)| self.filters.matches_topic(&tp.topic))
@@ -224,95 +264,116 @@ impl OffsetCollector {
             });
         }
 
-        // Filter watermarks by topic
-        let filtered_watermarks: HashMap<TopicPartition, (i64, i64)> = watermarks
-            .into_iter()
-            .filter(|(tp, _)| self.filters.matches_topic(&tp.topic))
-            .collect();
-
         let elapsed = start.elapsed();
         debug!(
             elapsed_ms = elapsed.as_millis(),
-            "Parallel collection completed"
+            monitored_topics = monitored_topics.len(),
+            compacted_topics = compacted_topics.len(),
+            "Batched collection completed"
         );
 
         Ok(OffsetsSnapshot {
             cluster_name: self.client.cluster_name().to_string(),
             groups,
-            watermarks: filtered_watermarks,
+            watermarks,
+            compacted_topics,
             timestamp_ms: chrono_timestamp_ms(),
         })
     }
 
-    /// Fetch offsets for all groups in parallel with bounded concurrency.
-    /// Uses the Admin API (ListConsumerGroupOffsets) through the shared AdminClient — no per-group consumers needed.
-    async fn fetch_all_group_offsets_parallel(
+    /// Compute the partition list this collector should monitor by applying
+    /// the topic whitelist/blacklist to the current cluster metadata. Runs
+    /// before any partition-touching Admin API call.
+    fn list_monitored_partitions(&self) -> Result<(Vec<TopicPartition>, Vec<String>)> {
+        let metadata = self.client.fetch_metadata()?;
+        let mut partitions = Vec::new();
+        let mut topics = Vec::new();
+        for topic in metadata.topics() {
+            let name = topic.name();
+            if !self.filters.matches_topic(name) {
+                continue;
+            }
+            topics.push(name.to_string());
+            for p in topic.partitions() {
+                partitions.push(TopicPartition::new(name, p.id()));
+            }
+        }
+        Ok((partitions, topics))
+    }
+
+    /// Fetch offsets for all groups via batched Admin API.
+    ///
+    /// librdkafka 2.12's `rd_kafka_ListConsumerGroupOffsets` rejects calls with
+    /// more than one group per call ("Exactly one ListConsumerGroupOffsets must
+    /// be passed") even though the Kafka protocol supports multi-group
+    /// ListOffsetFetch (KIP-709). We therefore issue one FFI call per group,
+    /// fanned out with bounded concurrency via `max_concurrent_groups`.
+    ///
+    /// The win vs. the prior path is not "multi-group in one call" but:
+    ///   - `NULL` partition list passed to each request → broker returns only
+    ///     committed partitions; no 19K-entry partition-list clone per group.
+    ///   - No per-group `spawn` of a 19K-entry Vec clone.
+    ///
+    /// Once librdkafka lifts the single-group restriction we can increase the
+    /// inner `chunk_size` without code changes beyond this constant.
+    async fn fetch_all_group_offsets_batched(
         &self,
-        descriptions: &[crate::kafka::client::GroupDescription],
-        watermarks: &HashMap<TopicPartition, (i64, i64)>,
+        group_ids: &[&str],
     ) -> HashMap<String, HashMap<TopicPartition, i64>> {
-        let max_concurrent = self.performance.max_concurrent_groups;
+        use crate::kafka::admin::list_consumer_group_offsets_batched;
+
+        if group_ids.is_empty() {
+            return HashMap::new();
+        }
+
+        // librdkafka constraint: one group per FFI call.
+        const PER_CALL_CHUNK: usize = 1;
+
         let offset_timeout = self.performance.offset_fetch_timeout;
+        let max_concurrent = self.performance.max_concurrent_groups;
 
         debug!(
-            groups = descriptions.len(),
+            groups = group_ids.len(),
+            per_call_chunk = PER_CALL_CHUNK,
             max_concurrent = max_concurrent,
-            "Fetching group offsets in parallel via Admin API"
+            "Fetching group offsets (one call per group, fanned out)"
         );
 
         let semaphore = Arc::new(Semaphore::new(max_concurrent));
         let client = Arc::clone(&self.client);
-        let wm_keys: Vec<TopicPartition> = watermarks.keys().cloned().collect();
 
-        let mut handles = Vec::with_capacity(descriptions.len());
-
-        for desc in descriptions {
-            let group_id = desc.group_id.clone();
+        let mut handles = Vec::with_capacity(group_ids.len());
+        for gid in group_ids {
+            let gid = gid.to_string();
             let permit = semaphore.clone();
             let client_clone = Arc::clone(&client);
-            let partitions = wm_keys.clone();
-            let timeout = offset_timeout;
-
-            let handle = tokio::spawn(async move {
-                let permit_guard: OwnedSemaphorePermit =
+            handles.push(tokio::spawn(async move {
+                let _permit: OwnedSemaphorePermit =
                     permit.acquire_owned().await.expect("semaphore closed");
-
                 tokio::task::spawn_blocking(move || {
-                    let _permit = permit_guard;
-
-                    let offsets =
-                        client_clone.list_consumer_group_offsets(&group_id, &partitions, timeout);
-
-                    (group_id, offsets)
+                    list_consumer_group_offsets_batched(
+                        &client_clone.admin_handle(),
+                        &[gid.as_str()],
+                        offset_timeout,
+                        PER_CALL_CHUNK,
+                    )
                 })
                 .await
-            });
-
-            handles.push(handle);
+            }));
         }
 
         let results = futures::future::join_all(handles).await;
 
-        let mut all_offsets = HashMap::new();
-        for result in results {
-            match result {
-                Ok(Ok((group_id, Ok(offsets)))) => {
-                    all_offsets.insert(group_id, offsets);
-                }
-                Ok(Ok((group_id, Err(e)))) => {
-                    warn!(group = group_id, error = %e, "Failed to fetch group offsets");
-                    all_offsets.insert(group_id, HashMap::new());
-                }
-                Ok(Err(e)) => {
-                    warn!(error = %e, "Group offset fetch blocking task panicked");
-                }
-                Err(e) => {
-                    warn!(error = %e, "Group offset fetch task panicked");
-                }
+        let mut merged: HashMap<String, HashMap<TopicPartition, i64>> = HashMap::new();
+        for r in results {
+            match r {
+                Ok(Ok(Ok(map))) => merged.extend(map),
+                Ok(Ok(Err(e))) => warn!(error = %e, "Group-offset call failed"),
+                Ok(Err(e)) => warn!(error = %e, "Group-offset call task panicked"),
+                Err(e) => warn!(error = %e, "Group-offset join error"),
             }
         }
-
-        all_offsets
+        merged
     }
 }
 
@@ -362,6 +423,7 @@ mod tests {
                 },
             ],
             watermarks: HashMap::new(),
+            compacted_topics: HashSet::new(),
             timestamp_ms: 0,
         };
 

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -1,0 +1,74 @@
+//! Batched Admin API FFI wrappers around librdkafka's `rd_kafka_*` functions.
+//!
+//! These wrappers provide per-cycle bulk operations that replace per-partition
+//! / per-group call fan-outs. All `unsafe` blocks are isolated to this module
+//! and every C object allocated is released via an RAII guard on any exit path.
+//!
+//! The pattern mirrors the existing single-group `list_consumer_group_offsets`
+//! wrapper that currently lives in `kafka/client.rs`.
+
+use crate::error::{KlagError, Result};
+use crate::kafka::client::TopicPartition;
+use rdkafka::admin::AdminClient;
+use rdkafka::bindings::*;
+use rdkafka::client::DefaultClientContext;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+/// Offset spec for `list_offsets_batched` — mirrors `RD_KAFKA_OFFSET_SPEC_*`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OffsetSpec {
+    Earliest,
+    Latest,
+}
+
+impl OffsetSpec {
+    fn as_c_value(self) -> i64 {
+        match self {
+            OffsetSpec::Earliest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_EARLIEST as i64,
+            OffsetSpec::Latest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_LATEST as i64,
+        }
+    }
+}
+
+/// Copy the librdkafka errstr buffer out as a String.
+pub(crate) fn errstr_to_string(buf: &[c_char]) -> String {
+    // SAFETY: librdkafka null-terminates; buf is a stack array owned by caller.
+    unsafe { CStr::from_ptr(buf.as_ptr()).to_string_lossy().to_string() }
+}
+
+/// Build a C cstring from a Rust &str, returning a KlagError on embedded NULs.
+pub(crate) fn cstring_or_err(s: &str) -> Result<CString> {
+    CString::new(s).map_err(|e| KlagError::Admin(format!("Invalid C string '{s}': {e}")))
+}
+
+/// Keep the admin client alive for the duration of an FFI call. This type is
+/// intentionally opaque: callers pass `&AdminClient` and we hold references
+/// that must not outlive it.
+pub(crate) fn admin_native_ptr(admin: &AdminClient<DefaultClientContext>) -> *mut rd_kafka_t {
+    admin.inner().native_ptr()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cstring_or_err_rejects_embedded_nul() {
+        let err = cstring_or_err("bad\0name").unwrap_err();
+        assert!(err.to_string().contains("Invalid C string"));
+    }
+
+    #[test]
+    fn cstring_or_err_accepts_normal_string() {
+        let s = cstring_or_err("my-group").unwrap();
+        assert_eq!(s.to_str().unwrap(), "my-group");
+    }
+
+    #[test]
+    fn offset_spec_constants_match_librdkafka() {
+        // RD_KAFKA_OFFSET_SPEC_EARLIEST == -2, _LATEST == -1 (from rdkafka.h).
+        assert_eq!(OffsetSpec::Earliest.as_c_value(), -2);
+        assert_eq!(OffsetSpec::Latest.as_c_value(), -1);
+    }
+}

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -486,6 +486,223 @@ unsafe fn ptr_to_string(p: *const c_char) -> String {
     }
 }
 
+/// Fetch committed offsets for many consumer groups in one batched Admin API
+/// call. Passes `NULL` partition list for each group, so the broker returns
+/// every committed partition — downstream topic filtering is applied on the
+/// (much smaller) response.
+///
+/// Chunks groups into sub-calls of at most `chunk_size` groups each.
+pub fn list_consumer_group_offsets_batched(
+    admin: &AdminClient<DefaultClientContext>,
+    group_ids: &[&str],
+    timeout: Duration,
+    chunk_size: usize,
+) -> Result<HashMap<String, HashMap<TopicPartition, i64>>> {
+    if group_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let chunk_size = chunk_size.max(1);
+    let mut out = HashMap::with_capacity(group_ids.len());
+    for chunk in group_ids.chunks(chunk_size) {
+        let part = list_consumer_group_offsets_one_chunk(admin, chunk, timeout)?;
+        out.extend(part);
+    }
+    Ok(out)
+}
+
+fn list_consumer_group_offsets_one_chunk(
+    admin: &AdminClient<DefaultClientContext>,
+    group_ids: &[&str],
+    timeout: Duration,
+) -> Result<HashMap<String, HashMap<TopicPartition, i64>>> {
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+    let rk = admin_native_ptr(admin);
+
+    let cstrings: Vec<CString> = group_ids
+        .iter()
+        .map(|g| cstring_or_err(g))
+        .collect::<Result<Vec<_>>>()?;
+
+    struct Cleanup {
+        requests: Vec<*mut rd_kafka_ListConsumerGroupOffsets_t>,
+        options: *mut rd_kafka_AdminOptions_t,
+        queue: *mut rd_kafka_queue_t,
+        event: *mut rd_kafka_event_t,
+    }
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.event.is_null() {
+                    rd_kafka_event_destroy(self.event);
+                }
+                if !self.queue.is_null() {
+                    rd_kafka_queue_destroy(self.queue);
+                }
+                if !self.options.is_null() {
+                    rd_kafka_AdminOptions_destroy(self.options);
+                }
+                for r in self.requests.drain(..) {
+                    if !r.is_null() {
+                        rd_kafka_ListConsumerGroupOffsets_destroy(r);
+                    }
+                }
+            }
+        }
+    }
+
+    unsafe {
+        let mut cleanup = Cleanup {
+            requests: Vec::with_capacity(cstrings.len()),
+            options: ptr::null_mut(),
+            queue: ptr::null_mut(),
+            event: ptr::null_mut(),
+        };
+
+        for c in &cstrings {
+            // NULL partition list → broker returns every committed partition
+            // for this group. Eliminates the 19K-entry partition-list clone
+            // amplifier from the old per-group call path.
+            let req = rd_kafka_ListConsumerGroupOffsets_new(c.as_ptr(), ptr::null_mut());
+            if req.is_null() {
+                return Err(KlagError::Admin(
+                    "Failed to create ListConsumerGroupOffsets request".into(),
+                ));
+            }
+            cleanup.requests.push(req);
+        }
+
+        let options = rd_kafka_AdminOptions_new(
+            rk,
+            rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPOFFSETS,
+        );
+        if options.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create AdminOptions (ListConsumerGroupOffsets)".into(),
+            ));
+        }
+        cleanup.options = options;
+
+        let mut errstr_buf = [0 as c_char; 512];
+        let err = rd_kafka_AdminOptions_set_request_timeout(
+            options,
+            timeout_ms,
+            errstr_buf.as_mut_ptr(),
+            errstr_buf.len(),
+        );
+        if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            return Err(KlagError::Admin(format!(
+                "Failed to set request timeout (ListConsumerGroupOffsets batched): {}",
+                errstr_to_string(&errstr_buf)
+            )));
+        }
+
+        let queue = rd_kafka_queue_new(rk);
+        if queue.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create queue (ListConsumerGroupOffsets batched)".into(),
+            ));
+        }
+        cleanup.queue = queue;
+
+        rd_kafka_ListConsumerGroupOffsets(
+            rk,
+            cleanup.requests.as_mut_ptr(),
+            cleanup.requests.len(),
+            options,
+            queue,
+        );
+
+        let event = rd_kafka_queue_poll(queue, timeout_ms);
+        if event.is_null() {
+            return Err(KlagError::Admin(
+                "ListConsumerGroupOffsets (batched) timed out".into(),
+            ));
+        }
+        cleanup.event = event;
+
+        let event_type = rd_kafka_event_type(event);
+        if event_type != RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT {
+            return Err(KlagError::Admin(format!(
+                "Unexpected event type (ListConsumerGroupOffsets batched): {event_type}"
+            )));
+        }
+
+        let resp_err = rd_kafka_event_error(event);
+        if resp_err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            let err_cstr = rd_kafka_event_error_string(event);
+            let err_msg = if err_cstr.is_null() {
+                "unknown error".to_string()
+            } else {
+                CStr::from_ptr(err_cstr).to_string_lossy().to_string()
+            };
+            return Err(KlagError::Admin(format!(
+                "ListConsumerGroupOffsets (batched) failed: {err_msg}"
+            )));
+        }
+
+        let result = rd_kafka_event_ListConsumerGroupOffsets_result(event);
+        if result.is_null() {
+            return Err(KlagError::Admin(
+                "ListConsumerGroupOffsets (batched) result is null".into(),
+            ));
+        }
+
+        let mut n_groups: usize = 0;
+        let groups_ptr =
+            rd_kafka_ListConsumerGroupOffsets_result_groups(result, &mut n_groups);
+        let mut out: HashMap<String, HashMap<TopicPartition, i64>> =
+            HashMap::with_capacity(n_groups);
+        if groups_ptr.is_null() || n_groups == 0 {
+            return Ok(out);
+        }
+
+        for i in 0..n_groups {
+            let group = *groups_ptr.add(i);
+            let group_name = rd_kafka_group_result_name(group);
+            let group_id = ptr_to_string(group_name);
+
+            let group_error = rd_kafka_group_result_error(group);
+            if !group_error.is_null() {
+                let code = rd_kafka_error_code(group_error);
+                if code != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+                    let msg = ptr_to_string(rd_kafka_error_string(group_error));
+                    warn!(group = %group_id, error = %msg, "ListConsumerGroupOffsets per-group error");
+                    out.insert(group_id, HashMap::new());
+                    continue;
+                }
+            }
+
+            let partitions = rd_kafka_group_result_partitions(group);
+            let mut offsets = HashMap::new();
+            if !partitions.is_null() {
+                let cnt = (*partitions).cnt;
+                let elems = (*partitions).elems;
+                if !elems.is_null() {
+                    for j in 0..cnt {
+                        let elem = &*elems.add(j as usize);
+                        // offset == RD_KAFKA_OFFSET_INVALID (-1001) means no committed offset.
+                        if elem.offset >= 0 && !elem.topic.is_null() {
+                            let topic = CStr::from_ptr(elem.topic).to_string_lossy().to_string();
+                            offsets.insert(
+                                TopicPartition::new(topic, elem.partition),
+                                elem.offset,
+                            );
+                        }
+                    }
+                }
+            }
+            out.insert(group_id, offsets);
+        }
+
+        debug!(
+            requested = group_ids.len(),
+            returned = out.len(),
+            "Batched ListConsumerGroupOffsets complete"
+        );
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -251,6 +251,241 @@ pub fn list_offsets_batched(
     }
 }
 
+/// Ready-to-consume representation of a consumer group description. Mirrors
+/// `kafka::client::GroupDescription` shape so callers don't need to translate
+/// beyond trivial field rename.
+#[derive(Debug, Clone)]
+pub struct BatchedGroupDescription {
+    pub group_id: String,
+    pub state: String,
+    pub members: Vec<BatchedMember>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BatchedMember {
+    pub member_id: String,
+    pub client_id: String,
+    pub client_host: String,
+    pub assignments: Vec<TopicPartition>,
+}
+
+/// Describe consumer groups in batches via `rd_kafka_DescribeConsumerGroups`.
+/// Chunks the input into sub-calls of at most `chunk_size` groups each and
+/// aggregates results. Per-group errors are logged at WARN and the group is
+/// omitted from the returned Vec.
+pub fn describe_consumer_groups_batched(
+    admin: &AdminClient<DefaultClientContext>,
+    group_ids: &[&str],
+    timeout: Duration,
+    chunk_size: usize,
+) -> Result<Vec<BatchedGroupDescription>> {
+    if group_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let chunk_size = chunk_size.max(1);
+    let mut out = Vec::with_capacity(group_ids.len());
+    for chunk in group_ids.chunks(chunk_size) {
+        let mut part = describe_consumer_groups_one_chunk(admin, chunk, timeout)?;
+        out.append(&mut part);
+    }
+    Ok(out)
+}
+
+fn describe_consumer_groups_one_chunk(
+    admin: &AdminClient<DefaultClientContext>,
+    group_ids: &[&str],
+    timeout: Duration,
+) -> Result<Vec<BatchedGroupDescription>> {
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+    let rk = admin_native_ptr(admin);
+
+    // Build array of *const c_char pointing to CString buffers. `cstrings`
+    // must outlive the FFI call (ptrs borrow from it).
+    let cstrings: Vec<CString> = group_ids
+        .iter()
+        .map(|g| cstring_or_err(g))
+        .collect::<Result<Vec<_>>>()?;
+    let mut ptrs: Vec<*const c_char> = cstrings.iter().map(|c| c.as_ptr()).collect();
+
+    struct Cleanup {
+        options: *mut rd_kafka_AdminOptions_t,
+        queue: *mut rd_kafka_queue_t,
+        event: *mut rd_kafka_event_t,
+    }
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.event.is_null() {
+                    rd_kafka_event_destroy(self.event);
+                }
+                if !self.queue.is_null() {
+                    rd_kafka_queue_destroy(self.queue);
+                }
+                if !self.options.is_null() {
+                    rd_kafka_AdminOptions_destroy(self.options);
+                }
+            }
+        }
+    }
+
+    unsafe {
+        let options = rd_kafka_AdminOptions_new(
+            rk,
+            rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_DESCRIBECONSUMERGROUPS,
+        );
+        if options.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create AdminOptions (DescribeConsumerGroups)".into(),
+            ));
+        }
+        let mut cleanup = Cleanup {
+            options,
+            queue: ptr::null_mut(),
+            event: ptr::null_mut(),
+        };
+
+        let mut errstr_buf = [0 as c_char; 512];
+        let err = rd_kafka_AdminOptions_set_request_timeout(
+            options,
+            timeout_ms,
+            errstr_buf.as_mut_ptr(),
+            errstr_buf.len(),
+        );
+        if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            return Err(KlagError::Admin(format!(
+                "Failed to set request timeout (DescribeConsumerGroups): {}",
+                errstr_to_string(&errstr_buf)
+            )));
+        }
+
+        let queue = rd_kafka_queue_new(rk);
+        if queue.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create queue (DescribeConsumerGroups)".into(),
+            ));
+        }
+        cleanup.queue = queue;
+
+        rd_kafka_DescribeConsumerGroups(rk, ptrs.as_mut_ptr(), ptrs.len(), options, queue);
+
+        let event = rd_kafka_queue_poll(queue, timeout_ms);
+        if event.is_null() {
+            return Err(KlagError::Admin(
+                "DescribeConsumerGroups timed out".into(),
+            ));
+        }
+        cleanup.event = event;
+
+        let event_type = rd_kafka_event_type(event);
+        if event_type != RD_KAFKA_EVENT_DESCRIBECONSUMERGROUPS_RESULT {
+            return Err(KlagError::Admin(format!(
+                "Unexpected event type (DescribeConsumerGroups): {event_type}"
+            )));
+        }
+
+        let resp_err = rd_kafka_event_error(event);
+        if resp_err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            let err_cstr = rd_kafka_event_error_string(event);
+            let err_msg = if err_cstr.is_null() {
+                "unknown error".to_string()
+            } else {
+                CStr::from_ptr(err_cstr).to_string_lossy().to_string()
+            };
+            return Err(KlagError::Admin(format!(
+                "DescribeConsumerGroups failed: {err_msg}"
+            )));
+        }
+
+        let result = rd_kafka_event_DescribeConsumerGroups_result(event);
+        if result.is_null() {
+            return Err(KlagError::Admin(
+                "DescribeConsumerGroups result is null".into(),
+            ));
+        }
+
+        let mut n: usize = 0;
+        let groups_ptr = rd_kafka_DescribeConsumerGroups_result_groups(result, &mut n);
+        let mut out = Vec::with_capacity(n);
+        if groups_ptr.is_null() || n == 0 {
+            return Ok(out);
+        }
+
+        for i in 0..n {
+            let grp = *groups_ptr.add(i);
+            let group_id = ptr_to_string(rd_kafka_ConsumerGroupDescription_group_id(grp));
+            let grp_err = rd_kafka_ConsumerGroupDescription_error(grp);
+            if !grp_err.is_null() {
+                let code = rd_kafka_error_code(grp_err);
+                if code != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+                    let msg = ptr_to_string(rd_kafka_error_string(grp_err));
+                    warn!(group = %group_id, error = %msg, "DescribeConsumerGroups per-group error");
+                    continue;
+                }
+            }
+
+            let state = rd_kafka_ConsumerGroupDescription_state(grp);
+            let state_str = ptr_to_string(rd_kafka_consumer_group_state_name(state));
+
+            let member_count = rd_kafka_ConsumerGroupDescription_member_count(grp);
+            let mut members = Vec::with_capacity(member_count);
+            for m_idx in 0..member_count {
+                let member = rd_kafka_ConsumerGroupDescription_member(grp, m_idx);
+                if member.is_null() {
+                    continue;
+                }
+                let member_id = ptr_to_string(rd_kafka_MemberDescription_consumer_id(member));
+                let client_id = ptr_to_string(rd_kafka_MemberDescription_client_id(member));
+                let client_host = ptr_to_string(rd_kafka_MemberDescription_host(member));
+
+                let assignment = rd_kafka_MemberDescription_assignment(member);
+                let mut assignments = Vec::new();
+                if !assignment.is_null() {
+                    let tpl_ptr = rd_kafka_MemberAssignment_partitions(assignment);
+                    if !tpl_ptr.is_null() {
+                        let tpl = &*tpl_ptr;
+                        for j in 0..tpl.cnt {
+                            let el = &*tpl.elems.add(j as usize);
+                            if el.topic.is_null() {
+                                continue;
+                            }
+                            let topic = CStr::from_ptr(el.topic).to_string_lossy().to_string();
+                            assignments.push(TopicPartition::new(topic, el.partition));
+                        }
+                    }
+                }
+
+                members.push(BatchedMember {
+                    member_id,
+                    client_id,
+                    client_host,
+                    assignments,
+                });
+            }
+
+            out.push(BatchedGroupDescription {
+                group_id,
+                state: state_str,
+                members,
+            });
+        }
+
+        debug!(
+            requested = group_ids.len(),
+            returned = out.len(),
+            "Batched DescribeConsumerGroups complete"
+        );
+        Ok(out)
+    }
+}
+
+unsafe fn ptr_to_string(p: *const c_char) -> String {
+    if p.is_null() {
+        String::new()
+    } else {
+        CStr::from_ptr(p).to_string_lossy().to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -12,8 +12,12 @@ use crate::kafka::client::TopicPartition;
 use rdkafka::admin::AdminClient;
 use rdkafka::bindings::*;
 use rdkafka::client::DefaultClientContext;
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::ptr;
+use std::time::Duration;
+use tracing::{debug, warn};
 
 /// Offset spec for `list_offsets_batched` — mirrors `RD_KAFKA_OFFSET_SPEC_*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +51,204 @@ pub(crate) fn cstring_or_err(s: &str) -> Result<CString> {
 /// that must not outlive it.
 pub(crate) fn admin_native_ptr(admin: &AdminClient<DefaultClientContext>) -> *mut rd_kafka_t {
     admin.inner().native_ptr()
+}
+
+/// Fetch offsets (EARLIEST or LATEST per `spec`) for a set of partitions in a
+/// single batched Admin API call. librdkafka routes per leader broker
+/// internally, collapsing O(partitions) round trips to O(brokers).
+///
+/// Partial failure policy: per-partition errors are logged at WARN and omitted
+/// from the returned map. Top-level event errors propagate as `KlagError::Admin`.
+pub fn list_offsets_batched(
+    admin: &AdminClient<DefaultClientContext>,
+    partitions: &[TopicPartition],
+    spec: OffsetSpec,
+    timeout: Duration,
+) -> Result<HashMap<TopicPartition, i64>> {
+    if partitions.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+    let rk = admin_native_ptr(admin);
+
+    // RAII cleanup guard — mirrors existing pattern in client.rs.
+    struct Cleanup {
+        tpl: *mut rd_kafka_topic_partition_list_t,
+        options: *mut rd_kafka_AdminOptions_t,
+        queue: *mut rd_kafka_queue_t,
+        event: *mut rd_kafka_event_t,
+        _topic_cstrings: Vec<CString>,
+    }
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.event.is_null() {
+                    rd_kafka_event_destroy(self.event);
+                }
+                if !self.queue.is_null() {
+                    rd_kafka_queue_destroy(self.queue);
+                }
+                if !self.options.is_null() {
+                    rd_kafka_AdminOptions_destroy(self.options);
+                }
+                // rd_kafka_ListOffsets does NOT take ownership — free it ourselves.
+                if !self.tpl.is_null() {
+                    rd_kafka_topic_partition_list_destroy(self.tpl);
+                }
+            }
+        }
+    }
+
+    unsafe {
+        let c_tpl = rd_kafka_topic_partition_list_new(partitions.len() as i32);
+        if c_tpl.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create topic partition list".into(),
+            ));
+        }
+
+        let mut cleanup = Cleanup {
+            tpl: c_tpl,
+            options: ptr::null_mut(),
+            queue: ptr::null_mut(),
+            event: ptr::null_mut(),
+            _topic_cstrings: Vec::with_capacity(partitions.len()),
+        };
+
+        let spec_value = spec.as_c_value();
+        for tp in partitions {
+            let topic_cstr = cstring_or_err(&tp.topic)?;
+            cleanup._topic_cstrings.push(topic_cstr);
+            let cstr_ptr = cleanup._topic_cstrings.last().unwrap().as_ptr();
+            let elem = rd_kafka_topic_partition_list_add(c_tpl, cstr_ptr, tp.partition);
+            if elem.is_null() {
+                return Err(KlagError::Admin(
+                    "Failed to add partition to ListOffsets request".into(),
+                ));
+            }
+            // ListOffsets API: offset field holds the OffsetSpec sentinel.
+            (*elem).offset = spec_value;
+        }
+
+        let options = rd_kafka_AdminOptions_new(
+            rk,
+            rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTOFFSETS,
+        );
+        if options.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create AdminOptions (ListOffsets)".into(),
+            ));
+        }
+        cleanup.options = options;
+
+        let mut errstr_buf = [0 as c_char; 512];
+        let err = rd_kafka_AdminOptions_set_request_timeout(
+            options,
+            timeout_ms,
+            errstr_buf.as_mut_ptr(),
+            errstr_buf.len(),
+        );
+        if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            return Err(KlagError::Admin(format!(
+                "Failed to set request timeout (ListOffsets): {}",
+                errstr_to_string(&errstr_buf)
+            )));
+        }
+
+        let queue = rd_kafka_queue_new(rk);
+        if queue.is_null() {
+            return Err(KlagError::Admin(
+                "Failed to create queue (ListOffsets)".into(),
+            ));
+        }
+        cleanup.queue = queue;
+
+        rd_kafka_ListOffsets(rk, c_tpl, options, queue);
+
+        let event = rd_kafka_queue_poll(queue, timeout_ms);
+        if event.is_null() {
+            return Err(KlagError::Admin("ListOffsets timed out".into()));
+        }
+        cleanup.event = event;
+
+        let event_type = rd_kafka_event_type(event);
+        if event_type != RD_KAFKA_EVENT_LISTOFFSETS_RESULT {
+            return Err(KlagError::Admin(format!(
+                "Unexpected event type (ListOffsets): {event_type}"
+            )));
+        }
+
+        let resp_err = rd_kafka_event_error(event);
+        if resp_err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+            let err_cstr = rd_kafka_event_error_string(event);
+            let err_msg = if err_cstr.is_null() {
+                "unknown error".to_string()
+            } else {
+                CStr::from_ptr(err_cstr).to_string_lossy().to_string()
+            };
+            return Err(KlagError::Admin(format!("ListOffsets failed: {err_msg}")));
+        }
+
+        let result = rd_kafka_event_ListOffsets_result(event);
+        if result.is_null() {
+            return Err(KlagError::Admin("ListOffsets result is null".into()));
+        }
+
+        let mut n_infos: usize = 0;
+        let infos_ptr = rd_kafka_ListOffsets_result_infos(result, &mut n_infos);
+        let mut out = HashMap::with_capacity(n_infos);
+
+        if infos_ptr.is_null() || n_infos == 0 {
+            debug!(spec = ?spec, "No ListOffsets results returned");
+            return Ok(out);
+        }
+
+        for i in 0..n_infos {
+            let info = *infos_ptr.add(i);
+            let tp_ptr = rd_kafka_ListOffsetsResultInfo_topic_partition(info);
+            if tp_ptr.is_null() {
+                continue;
+            }
+            let tp_ref = &*tp_ptr;
+
+            if tp_ref.err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+                let err_name = rd_kafka_err2name(tp_ref.err);
+                let err_str = if err_name.is_null() {
+                    "unknown".to_string()
+                } else {
+                    CStr::from_ptr(err_name).to_string_lossy().to_string()
+                };
+                let topic = if tp_ref.topic.is_null() {
+                    "<null>".to_string()
+                } else {
+                    CStr::from_ptr(tp_ref.topic).to_string_lossy().to_string()
+                };
+                warn!(
+                    topic = %topic,
+                    partition = tp_ref.partition,
+                    spec = ?spec,
+                    error = %err_str,
+                    "ListOffsets per-partition error"
+                );
+                continue;
+            }
+
+            if tp_ref.topic.is_null() {
+                continue;
+            }
+            let topic = CStr::from_ptr(tp_ref.topic).to_string_lossy().to_string();
+            out.insert(TopicPartition::new(topic, tp_ref.partition), tp_ref.offset);
+        }
+
+        debug!(
+            spec = ?spec,
+            requested = partitions.len(),
+            returned = out.len(),
+            "Batched ListOffsets complete"
+        );
+        Ok(out)
+    }
 }
 
 #[cfg(test)]

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -131,10 +131,8 @@ pub fn list_offsets_batched(
             (*elem).offset = spec_value;
         }
 
-        let options = rd_kafka_AdminOptions_new(
-            rk,
-            rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTOFFSETS,
-        );
+        let options =
+            rd_kafka_AdminOptions_new(rk, rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTOFFSETS);
         if options.is_null() {
             return Err(KlagError::Admin(
                 "Failed to create AdminOptions (ListOffsets)".into(),
@@ -370,9 +368,7 @@ fn describe_consumer_groups_one_chunk(
 
         let event = rd_kafka_queue_poll(queue, timeout_ms);
         if event.is_null() {
-            return Err(KlagError::Admin(
-                "DescribeConsumerGroups timed out".into(),
-            ));
+            return Err(KlagError::Admin("DescribeConsumerGroups timed out".into()));
         }
         cleanup.event = event;
 
@@ -648,8 +644,7 @@ fn list_consumer_group_offsets_one_chunk(
         }
 
         let mut n_groups: usize = 0;
-        let groups_ptr =
-            rd_kafka_ListConsumerGroupOffsets_result_groups(result, &mut n_groups);
+        let groups_ptr = rd_kafka_ListConsumerGroupOffsets_result_groups(result, &mut n_groups);
         let mut out: HashMap<String, HashMap<TopicPartition, i64>> =
             HashMap::with_capacity(n_groups);
         if groups_ptr.is_null() || n_groups == 0 {
@@ -683,10 +678,7 @@ fn list_consumer_group_offsets_one_chunk(
                         // offset == RD_KAFKA_OFFSET_INVALID (-1001) means no committed offset.
                         if elem.offset >= 0 && !elem.topic.is_null() {
                             let topic = CStr::from_ptr(elem.topic).to_string_lossy().to_string();
-                            offsets.insert(
-                                TopicPartition::new(topic, elem.partition),
-                                elem.offset,
-                            );
+                            offsets.insert(TopicPartition::new(topic, elem.partition), elem.offset);
                         }
                     }
                 }

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -2,10 +2,13 @@
 //!
 //! These wrappers provide per-cycle bulk operations that replace per-partition
 //! / per-group call fan-outs. All `unsafe` blocks are isolated to this module
-//! and every C object allocated is released via an RAII guard on any exit path.
+//! and every C object allocated is released via an RAII guard on any exit
+//! path (panic-safe).
 //!
-//! The pattern mirrors the existing single-group `list_consumer_group_offsets`
-//! wrapper that currently lives in `kafka/client.rs`.
+//! The cleanup-guard pattern originated with the single-group
+//! `list_consumer_group_offsets` wrapper introduced in commit `9e46820` /
+//! PR #57 (FFI memory-leak fix). That single-group wrapper was replaced by
+//! the batched functions in this module; the pattern is preserved.
 
 use crate::error::{KlagError, Result};
 use crate::kafka::client::TopicPartition;

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -6,13 +6,9 @@ use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::groups::GroupList;
 use rdkafka::metadata::Metadata;
-use rdkafka::TopicPartitionList;
 use std::collections::{HashMap, HashSet};
-use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, instrument, warn};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -56,13 +52,6 @@ pub struct GroupDescription {
     #[allow(dead_code)]
     pub protocol: String,
     pub members: Vec<GroupMemberInfo>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
-pub enum OffsetPosition {
-    Earliest,
-    Latest,
 }
 
 pub struct KafkaClient {
@@ -211,8 +200,7 @@ impl KafkaClient {
         use crate::kafka::admin::describe_consumer_groups_batched;
 
         let admin = self.admin();
-        let batched =
-            describe_consumer_groups_batched(&admin, group_ids, self.timeout, 100)?;
+        let batched = describe_consumer_groups_batched(&admin, group_ids, self.timeout, 100)?;
 
         Ok(batched
             .into_iter()
@@ -233,233 +221,6 @@ impl KafkaClient {
                     .collect(),
             })
             .collect())
-    }
-
-    /// Fetch committed offsets for a consumer group using the Admin API.
-    /// Uses the existing AdminClient connection — no additional consumers/FDs needed.
-    #[instrument(skip(self, partitions), fields(cluster = %self.config.name, group = %group_id))]
-    pub fn list_consumer_group_offsets(
-        &self,
-        group_id: &str,
-        partitions: &[TopicPartition],
-        timeout: Duration,
-    ) -> Result<HashMap<TopicPartition, i64>> {
-        use rdkafka::bindings::*;
-
-        let group_cstr = CString::new(group_id)
-            .map_err(|e| KlagError::Admin(format!("Invalid group_id contains null byte: {e}")))?;
-        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
-
-        // Hold an Arc to the admin client for the duration of the FFI call
-        // to keep the native rd_kafka_t handle valid.
-        let admin = self.admin();
-
-        unsafe {
-            let rk = admin.inner().native_ptr();
-
-            // Build the C topic-partition list from our partitions
-            let c_tpl = rd_kafka_topic_partition_list_new(partitions.len() as i32);
-            if c_tpl.is_null() {
-                return Err(KlagError::Admin(
-                    "Failed to create topic partition list".into(),
-                ));
-            }
-
-            // RAII guard to clean up all C resources on any exit path
-            struct Cleanup {
-                tpl: *mut rd_kafka_topic_partition_list_t,
-                request: *mut rd_kafka_ListConsumerGroupOffsets_t,
-                options: *mut rd_kafka_AdminOptions_t,
-                queue: *mut rd_kafka_queue_t,
-                event: *mut rd_kafka_event_t,
-                // CStrings kept alive for the duration of the FFI call
-                _topic_cstrings: Vec<CString>,
-            }
-            impl Drop for Cleanup {
-                fn drop(&mut self) {
-                    unsafe {
-                        if !self.event.is_null() {
-                            rd_kafka_event_destroy(self.event);
-                        }
-                        if !self.queue.is_null() {
-                            rd_kafka_queue_destroy(self.queue);
-                        }
-                        if !self.options.is_null() {
-                            rd_kafka_AdminOptions_destroy(self.options);
-                        }
-                        if !self.request.is_null() {
-                            rd_kafka_ListConsumerGroupOffsets_destroy(self.request);
-                        }
-                        // tpl ownership is transferred to the request via
-                        // rd_kafka_ListConsumerGroupOffsets_new, which copies it.
-                        // We still own the original and must free it.
-                        if !self.tpl.is_null() {
-                            rd_kafka_topic_partition_list_destroy(self.tpl);
-                        }
-                    }
-                }
-            }
-
-            let mut cleanup = Cleanup {
-                tpl: c_tpl,
-                request: std::ptr::null_mut(),
-                options: std::ptr::null_mut(),
-                queue: std::ptr::null_mut(),
-                event: std::ptr::null_mut(),
-                _topic_cstrings: Vec::with_capacity(partitions.len()),
-            };
-
-            // Populate the partition list
-            for tp in partitions {
-                let topic_cstr = CString::new(tp.topic.as_str())
-                    .map_err(|e| KlagError::Admin(format!("Topic name contains null byte: {e}")))?;
-                cleanup._topic_cstrings.push(topic_cstr);
-                let cstr_ptr = cleanup._topic_cstrings.last().unwrap().as_ptr();
-                rd_kafka_topic_partition_list_add(c_tpl, cstr_ptr, tp.partition);
-            }
-
-            // Create the request object
-            let request = rd_kafka_ListConsumerGroupOffsets_new(group_cstr.as_ptr(), c_tpl);
-            if request.is_null() {
-                return Err(KlagError::Admin(
-                    "Failed to create ListConsumerGroupOffsets request".into(),
-                ));
-            }
-            cleanup.request = request;
-
-            // Create admin options with timeout
-            let options = rd_kafka_AdminOptions_new(
-                rk,
-                rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPOFFSETS,
-            );
-            if options.is_null() {
-                return Err(KlagError::Admin("Failed to create AdminOptions".into()));
-            }
-            cleanup.options = options;
-
-            let mut errstr_buf = [0 as c_char; 512];
-            let err = rd_kafka_AdminOptions_set_request_timeout(
-                options,
-                timeout_ms,
-                errstr_buf.as_mut_ptr(),
-                errstr_buf.len(),
-            );
-            if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-                let errstr = CStr::from_ptr(errstr_buf.as_ptr())
-                    .to_string_lossy()
-                    .to_string();
-                return Err(KlagError::Admin(format!(
-                    "Failed to set request timeout: {errstr}"
-                )));
-            }
-
-            // Create a temporary queue for the async result
-            let queue = rd_kafka_queue_new(rk);
-            if queue.is_null() {
-                return Err(KlagError::Admin("Failed to create queue".into()));
-            }
-            cleanup.queue = queue;
-
-            // Issue the async call — caller retains ownership of request
-            let mut request_ptr = request;
-            rd_kafka_ListConsumerGroupOffsets(rk, &mut request_ptr, 1, options, queue);
-
-            // Poll for the result event (blocks up to timeout)
-            let event = rd_kafka_queue_poll(queue, timeout_ms);
-            if event.is_null() {
-                return Err(KlagError::Admin(
-                    "ListConsumerGroupOffsets timed out".into(),
-                ));
-            }
-            cleanup.event = event;
-
-            // Verify it's the right event type
-            let event_type = rd_kafka_event_type(event);
-            if event_type != RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT {
-                return Err(KlagError::Admin(format!(
-                    "Unexpected event type: {event_type}"
-                )));
-            }
-
-            // Check top-level error
-            let resp_err = rd_kafka_event_error(event);
-            if resp_err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-                let err_cstr = rd_kafka_event_error_string(event);
-                let err_msg = if err_cstr.is_null() {
-                    "unknown error".to_string()
-                } else {
-                    CStr::from_ptr(err_cstr).to_string_lossy().to_string()
-                };
-                return Err(KlagError::Admin(format!(
-                    "ListConsumerGroupOffsets failed: {err_msg}"
-                )));
-            }
-
-            // Extract the result
-            let result = rd_kafka_event_ListConsumerGroupOffsets_result(event);
-            if result.is_null() {
-                return Err(KlagError::Admin(
-                    "ListConsumerGroupOffsets result is null".into(),
-                ));
-            }
-
-            let mut n_groups: usize = 0;
-            let groups_ptr = rd_kafka_ListConsumerGroupOffsets_result_groups(result, &mut n_groups);
-
-            let mut offsets = HashMap::new();
-
-            if groups_ptr.is_null() || n_groups == 0 {
-                debug!(group = group_id, "No group results returned from Admin API");
-                return Ok(offsets);
-            }
-
-            for i in 0..n_groups {
-                let group = *groups_ptr.add(i);
-
-                // Check per-group error
-                let group_error = rd_kafka_group_result_error(group);
-                if !group_error.is_null() {
-                    let code = rd_kafka_error_code(group_error);
-                    if code != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-                        let err_str = rd_kafka_error_string(group_error);
-                        let msg = if err_str.is_null() {
-                            "unknown".to_string()
-                        } else {
-                            CStr::from_ptr(err_str).to_string_lossy().to_string()
-                        };
-                        warn!(group = group_id, error = %msg, "Group result error");
-                        continue;
-                    }
-                }
-
-                let result_partitions = rd_kafka_group_result_partitions(group);
-                if result_partitions.is_null() {
-                    continue;
-                }
-
-                let cnt = (*result_partitions).cnt;
-                let elems = (*result_partitions).elems;
-                if elems.is_null() {
-                    continue;
-                }
-
-                for j in 0..cnt {
-                    let elem = &*elems.add(j as usize);
-                    // offset == -1001 (RD_KAFKA_OFFSET_INVALID) means no committed offset
-                    if elem.offset >= 0 && !elem.topic.is_null() {
-                        let topic = CStr::from_ptr(elem.topic).to_string_lossy().to_string();
-                        offsets.insert(TopicPartition::new(topic, elem.partition), elem.offset);
-                    }
-                }
-            }
-
-            debug!(
-                group = group_id,
-                partitions = offsets.len(),
-                "Fetched committed offsets via Admin API"
-            );
-            Ok(offsets)
-        }
     }
 
     #[instrument(skip(self), fields(cluster = %self.config.name))]
@@ -487,10 +248,8 @@ impl KafkaClient {
         }
 
         let admin = self.admin();
-        let lows =
-            list_offsets_batched(&admin, partitions, OffsetSpec::Earliest, self.timeout)?;
-        let highs =
-            list_offsets_batched(&admin, partitions, OffsetSpec::Latest, self.timeout)?;
+        let lows = list_offsets_batched(&admin, partitions, OffsetSpec::Earliest, self.timeout)?;
+        let highs = list_offsets_batched(&admin, partitions, OffsetSpec::Latest, self.timeout)?;
 
         let mut merged = HashMap::with_capacity(partitions.len());
         for (tp, high) in highs {
@@ -504,174 +263,6 @@ impl KafkaClient {
             merged.entry(tp).or_insert((low, low));
         }
         Ok(merged)
-    }
-
-    #[allow(dead_code)]
-    #[instrument(skip(self, partitions), fields(cluster = %self.config.name, position = ?position, count = partitions.len()))]
-    pub fn list_offsets(
-        &self,
-        partitions: &[TopicPartition],
-        position: OffsetPosition,
-    ) -> Result<HashMap<TopicPartition, i64>> {
-        let mut tpl = TopicPartitionList::new();
-        for tp in partitions {
-            let offset = match position {
-                OffsetPosition::Earliest => rdkafka::Offset::Beginning,
-                OffsetPosition::Latest => rdkafka::Offset::End,
-            };
-            tpl.add_partition_offset(&tp.topic, tp.partition, offset)
-                .map_err(KlagError::Kafka)?;
-        }
-
-        let watermarks = self.fetch_watermarks_for_tpl(&tpl, position)?;
-        Ok(watermarks)
-    }
-
-    #[allow(dead_code)]
-    fn fetch_watermarks_for_tpl(
-        &self,
-        tpl: &TopicPartitionList,
-        position: OffsetPosition,
-    ) -> Result<HashMap<TopicPartition, i64>> {
-        let consumer = self.consumer();
-        let mut offsets = HashMap::new();
-
-        for elem in tpl.elements() {
-            let (low, high) = consumer
-                .fetch_watermarks(elem.topic(), elem.partition(), self.timeout)
-                .map_err(KlagError::Kafka)?;
-
-            let offset = match position {
-                OffsetPosition::Earliest => low,
-                OffsetPosition::Latest => high,
-            };
-
-            offsets.insert(TopicPartition::new(elem.topic(), elem.partition()), offset);
-        }
-
-        Ok(offsets)
-    }
-
-    /// Fetch watermarks sequentially (legacy method).
-    /// For large clusters, use `fetch_all_watermarks_parallel` instead.
-    #[allow(dead_code)]
-    pub fn fetch_all_watermarks(&self) -> Result<HashMap<TopicPartition, (i64, i64)>> {
-        let metadata = self.fetch_metadata()?;
-        let consumer = self.consumer();
-        let mut watermarks = HashMap::new();
-
-        for topic in metadata.topics() {
-            for partition in topic.partitions() {
-                match consumer.fetch_watermarks(topic.name(), partition.id(), self.timeout) {
-                    Ok((low, high)) => {
-                        watermarks.insert(
-                            TopicPartition::new(topic.name(), partition.id()),
-                            (low, high),
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            topic = topic.name(),
-                            partition = partition.id(),
-                            error = %e,
-                            "Failed to fetch watermarks"
-                        );
-                    }
-                }
-            }
-        }
-
-        Ok(watermarks)
-    }
-
-    /// Fetch watermarks for all partitions in parallel with bounded concurrency.
-    /// This is more efficient for large clusters with many partitions.
-    #[instrument(skip(self), fields(cluster = %self.config.name))]
-    pub async fn fetch_all_watermarks_parallel(
-        &self,
-    ) -> Result<HashMap<TopicPartition, (i64, i64)>> {
-        let metadata = self.fetch_metadata()?;
-        let max_concurrent = self.performance.max_concurrent_watermarks;
-
-        // Collect all topic-partition pairs
-        let partitions: Vec<(String, i32)> = metadata
-            .topics()
-            .iter()
-            .flat_map(|topic| {
-                topic
-                    .partitions()
-                    .iter()
-                    .map(move |p| (topic.name().to_string(), p.id()))
-            })
-            .collect();
-
-        let total_partitions = partitions.len();
-        debug!(
-            cluster = %self.config.name,
-            partitions = total_partitions,
-            max_concurrent = max_concurrent,
-            "Fetching watermarks in parallel"
-        );
-
-        // Use semaphore to limit concurrency
-        let semaphore = Arc::new(Semaphore::new(max_concurrent));
-        let consumer = self.consumer();
-        let timeout = self.timeout;
-
-        let mut handles = Vec::with_capacity(partitions.len());
-
-        for (topic, partition) in partitions {
-            let semaphore_clone = semaphore.clone();
-            let consumer_clone = Arc::clone(&consumer);
-
-            let handle = tokio::spawn(async move {
-                let permit: OwnedSemaphorePermit = semaphore_clone
-                    .acquire_owned()
-                    .await
-                    .expect("semaphore closed");
-
-                tokio::task::spawn_blocking(move || {
-                    let _permit = permit;
-
-                    match consumer_clone.fetch_watermarks(&topic, partition, timeout) {
-                        Ok((low, high)) => {
-                            Some((TopicPartition::new(&topic, partition), (low, high)))
-                        }
-                        Err(e) => {
-                            warn!(
-                                topic = topic,
-                                partition = partition,
-                                error = %e,
-                                "Failed to fetch watermarks"
-                            );
-                            None
-                        }
-                    }
-                })
-                .await
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for all tasks to complete (nested Result from tokio::spawn -> spawn_blocking)
-        let results = futures::future::join_all(handles).await;
-
-        let mut watermarks = HashMap::new();
-        for result in results {
-            if let Ok(Ok(Some((tp, wm)))) = result {
-                watermarks.insert(tp, wm);
-            }
-        }
-
-        debug!(
-            cluster = %self.config.name,
-            fetched = watermarks.len(),
-            total = total_partitions,
-            "Parallel watermark fetch completed"
-        );
-
-        Ok(watermarks)
     }
 
     #[allow(dead_code)]
@@ -737,67 +328,6 @@ impl KafkaClient {
 
         Ok(compacted_topics)
     }
-}
-
-fn parse_member_assignment(assignment: Option<&[u8]>) -> Option<Vec<TopicPartition>> {
-    let data = assignment?;
-    if data.len() < 4 {
-        return None;
-    }
-
-    let mut assignments = Vec::new();
-    let mut pos = 0;
-
-    // Skip version (2 bytes)
-    if data.len() < 2 {
-        return None;
-    }
-    pos += 2;
-
-    // Number of topics (4 bytes)
-    if data.len() < pos + 4 {
-        return None;
-    }
-    let num_topics = i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
-    pos += 4;
-
-    for _ in 0..num_topics {
-        // Topic name length (2 bytes)
-        if data.len() < pos + 2 {
-            break;
-        }
-        let topic_len = i16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
-        pos += 2;
-
-        // Topic name
-        if data.len() < pos + topic_len {
-            break;
-        }
-        let topic = String::from_utf8_lossy(&data[pos..pos + topic_len]).to_string();
-        pos += topic_len;
-
-        // Number of partitions (4 bytes)
-        if data.len() < pos + 4 {
-            break;
-        }
-        let num_partitions =
-            i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
-        pos += 4;
-
-        // Partitions
-        for _ in 0..num_partitions {
-            if data.len() < pos + 4 {
-                break;
-            }
-            let partition =
-                i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
-            pos += 4;
-
-            assignments.push(TopicPartition::new(&topic, partition));
-        }
-    }
-
-    Some(assignments)
 }
 
 /// Read current process RSS in kilobytes. Returns 0 on failure or non-Linux.

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -135,6 +135,14 @@ impl KafkaClient {
         Arc::clone(&self.admin.lock().unwrap_or_else(|p| p.into_inner()))
     }
 
+    /// Public accessor for the underlying AdminClient Arc. Used by batched
+    /// Admin API wrappers in `kafka::admin` and by integration tests. The
+    /// caller holds the Arc for the duration of the FFI call to keep the
+    /// native handle valid.
+    pub fn admin_handle(&self) -> Arc<AdminClient<DefaultClientContext>> {
+        self.admin()
+    }
+
     /// Get a snapshot of the current consumer (cheap Arc clone).
     fn consumer(&self) -> Arc<BaseConsumer> {
         Arc::clone(&self.consumer.lock().unwrap_or_else(|p| p.into_inner()))

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -253,7 +253,23 @@ impl KafkaClient {
 
         let mut merged = HashMap::with_capacity(partitions.len());
         for (tp, high) in highs {
-            let low = lows.get(&tp).copied().unwrap_or(0);
+            // If the EARLIEST call failed for this partition, fall back to
+            // `high` as the low watermark. This is conservative: it avoids
+            // a spurious data-loss alarm from the lag calculator (which
+            // flags `committed_offset < low_watermark`) while still surfacing
+            // valid lag numbers. A 0 default would misrepresent the earliest
+            // retained offset on compacted or retention-trimmed topics.
+            let low = match lows.get(&tp).copied() {
+                Some(l) => l,
+                None => {
+                    warn!(
+                        topic = %tp.topic,
+                        partition = tp.partition,
+                        "EARLIEST watermark missing; using LATEST as conservative fallback"
+                    );
+                    high
+                }
+            };
             merged.insert(tp, (low, high));
         }
         // Surface partitions where only EARLIEST returned (rare — usually both

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -201,44 +201,38 @@ impl KafkaClient {
         Ok(groups)
     }
 
+    /// Describe consumer groups via batched `rd_kafka_DescribeConsumerGroups`.
+    /// Replaces the prior sequential `fetch_group_list(Some(group_id))` loop
+    /// which dominated collection time on large clusters (O(groups) serial
+    /// round trips). `protocol_type`/`protocol` fields are not populated — they
+    /// are not consumed downstream (marked `#[allow(dead_code)]`).
     #[instrument(skip(self, group_ids), fields(cluster = %self.config.name, count = group_ids.len()))]
     pub fn describe_consumer_groups(&self, group_ids: &[&str]) -> Result<Vec<GroupDescription>> {
-        let consumer = self.consumer();
-        let mut descriptions = Vec::with_capacity(group_ids.len());
+        use crate::kafka::admin::describe_consumer_groups_batched;
 
-        for group_id in group_ids {
-            let group_list = consumer
-                .fetch_group_list(Some(group_id), self.timeout)
-                .map_err(KlagError::Kafka)?;
+        let admin = self.admin();
+        let batched =
+            describe_consumer_groups_batched(&admin, group_ids, self.timeout, 100)?;
 
-            for group in group_list.groups() {
-                let members = group
-                    .members()
-                    .iter()
-                    .map(|m| {
-                        let assignments =
-                            parse_member_assignment(m.assignment()).unwrap_or_default();
-
-                        GroupMemberInfo {
-                            member_id: m.id().to_string(),
-                            client_id: m.client_id().to_string(),
-                            client_host: m.client_host().to_string(),
-                            assignments,
-                        }
+        Ok(batched
+            .into_iter()
+            .map(|g| GroupDescription {
+                group_id: g.group_id,
+                state: g.state,
+                protocol_type: String::new(),
+                protocol: String::new(),
+                members: g
+                    .members
+                    .into_iter()
+                    .map(|m| GroupMemberInfo {
+                        member_id: m.member_id,
+                        client_id: m.client_id,
+                        client_host: m.client_host,
+                        assignments: m.assignments,
                     })
-                    .collect();
-
-                descriptions.push(GroupDescription {
-                    group_id: group.name().to_string(),
-                    state: group.state().to_string(),
-                    protocol_type: group.protocol_type().to_string(),
-                    protocol: group.protocol().to_string(),
-                    members,
-                });
-            }
-        }
-
-        Ok(descriptions)
+                    .collect(),
+            })
+            .collect())
     }
 
     /// Fetch committed offsets for a consumer group using the Admin API.

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -679,16 +679,16 @@ impl KafkaClient {
         AdminOptions::new().request_timeout(Some(self.timeout))
     }
 
-    /// Fetch topics that have compaction enabled (cleanup.policy contains "compact")
-    #[instrument(skip(self), fields(cluster = %self.config.name))]
-    pub async fn fetch_compacted_topics(&self) -> Result<HashSet<String>> {
-        let metadata = self.fetch_metadata()?;
-        let topic_names: Vec<String> = metadata
-            .topics()
-            .iter()
-            .map(|t| t.name().to_string())
-            .collect();
-
+    /// Fetch topics that have compaction enabled (cleanup.policy contains
+    /// "compact"), restricted to the supplied topic name list. Callers pass
+    /// the already-filtered monitored topic set to avoid paying the
+    /// full-cluster `DescribeConfigs` cost on clusters with thousands of
+    /// topics.
+    #[instrument(skip(self, topic_names), fields(cluster = %self.config.name, count = topic_names.len()))]
+    pub async fn fetch_compacted_topics_for(
+        &self,
+        topic_names: &[String],
+    ) -> Result<HashSet<String>> {
         if topic_names.is_empty() {
             return Ok(HashSet::new());
         }
@@ -710,16 +710,14 @@ impl KafkaClient {
         for result in results {
             match result {
                 Ok(resource) => {
-                    // Extract topic name from OwnedResourceSpecifier
                     let topic_name = match &resource.specifier {
                         rdkafka::admin::OwnedResourceSpecifier::Topic(name) => name.clone(),
-                        _ => continue, // Skip non-topic resources
+                        _ => continue,
                     };
                     for entry in resource.entries {
                         if entry.name == "cleanup.policy" {
                             if let Some(value) = entry.value {
                                 if value.contains("compact") {
-                                    debug!(topic = %topic_name, cleanup_policy = %value, "Topic has compaction enabled");
                                     compacted_topics.insert(topic_name.clone());
                                 }
                             }
@@ -727,17 +725,13 @@ impl KafkaClient {
                     }
                 }
                 Err(err) => {
-                    warn!(
-                        error = %err,
-                        "Failed to describe config for resource"
-                    );
+                    warn!(error = %err, "Failed to describe config for resource");
                 }
             }
         }
 
         debug!(
             count = compacted_topics.len(),
-            topics = ?compacted_topics,
             "Identified compacted topics"
         );
 

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -469,6 +469,43 @@ impl KafkaClient {
             .map_err(KlagError::Kafka)
     }
 
+    /// Fetch low + high watermarks for an explicit partition set via batched
+    /// ListOffsets. Two Admin API calls total (EARLIEST + LATEST), regardless
+    /// of partition count. Replaces the prior per-partition `fetch_watermarks`
+    /// fan-out (O(partitions) blocking calls via a semaphore).
+    ///
+    /// This is a blocking call — run inside `spawn_blocking` from async code.
+    #[instrument(skip(self, partitions), fields(cluster = %self.config.name, count = partitions.len()))]
+    pub fn fetch_watermarks_for_partitions(
+        &self,
+        partitions: &[TopicPartition],
+    ) -> Result<HashMap<TopicPartition, (i64, i64)>> {
+        use crate::kafka::admin::{list_offsets_batched, OffsetSpec};
+
+        if partitions.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let admin = self.admin();
+        let lows =
+            list_offsets_batched(&admin, partitions, OffsetSpec::Earliest, self.timeout)?;
+        let highs =
+            list_offsets_batched(&admin, partitions, OffsetSpec::Latest, self.timeout)?;
+
+        let mut merged = HashMap::with_capacity(partitions.len());
+        for (tp, high) in highs {
+            let low = lows.get(&tp).copied().unwrap_or(0);
+            merged.insert(tp, (low, high));
+        }
+        // Surface partitions where only EARLIEST returned (rare — usually both
+        // complete together, but a broker-level error on LATEST could leave us
+        // with low-only data).
+        for (tp, low) in lows {
+            merged.entry(tp).or_insert((low, low));
+        }
+        Ok(merged)
+    }
+
     #[allow(dead_code)]
     #[instrument(skip(self, partitions), fields(cluster = %self.config.name, position = ?position, count = partitions.len()))]
     pub fn list_offsets(

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod client;
 pub mod consumer;
 


### PR DESCRIPTION
## Summary

Tier 1 of the architectural rework tracked in #61. Replaces the per-partition / per-group librdkafka call fan-out with batched Admin API calls. Reduces per-cycle RPC count from O(partitions + groups) to O(brokers + groups).

On a cluster the size of #61's reporter (~7K topics / 19K partitions / 4K groups) the old path spent ~200s in a serial \`fetch_group_list\` loop alone — exceeding the 175s collection timeout. After this PR that loop is a single batched call.

## What changed

New module \`src/kafka/admin.rs\` isolating all new \`unsafe\` / FFI in one auditable file, with RAII cleanup on every exit path and partial-failure tolerance. Three batched wrappers:

- **\`list_offsets_batched\`** → \`rd_kafka_ListOffsets\`. Two calls per cycle (EARLIEST + LATEST). librdkafka routes per broker internally; replaces 19K per-partition \`fetch_watermarks\` tasks.
- **\`describe_consumer_groups_batched\`** → \`rd_kafka_DescribeConsumerGroups\`. Chunked 100 groups/request. Replaces the 4K-iteration sequential \`fetch_group_list(Some(group_id))\` loop.
- **\`list_consumer_group_offsets_batched\`** → multi-group \`rd_kafka_ListConsumerGroupOffsets\` with \`NULL\` partition list (broker returns only committed partitions). Eliminates the 76M-entry partition-list clone amplifier.

### Collector hot path rewire

\`OffsetCollector::collect_parallel\` now drives everything from a single filtered topic set:

- Topic whitelist/blacklist applied **before** watermark + DescribeConfigs calls. \`__consumer_offsets\` (50 partitions) and blacklisted topics are excluded from the hot path entirely.
- Compacted-topic lookup (\`fetch_compacted_topics_for\`) restricted to monitored topics and moved inside \`collect_parallel\` — surfaced through \`OffsetsSnapshot.compacted_topics\` so the cluster manager no longer issues its own RPC.
- Group offsets fan out via \`max_concurrent_groups\`, one group per FFI call.

### librdkafka 2.12 constraint (documented in code)

\`rd_kafka_ListConsumerGroupOffsets\` currently rejects multi-group calls at the client layer with *\"Exactly one ListConsumerGroupOffsets must be passed\"* even though KIP-709 is protocol-supported. We therefore issue one FFI call per group, fanned out with bounded concurrency. The wrapper is already multi-group-capable for when that restriction is lifted.

### Legacy removal

- \`OffsetPosition\` + \`KafkaClient::list_offsets\` + \`fetch_watermarks_for_tpl\` (per-partition watermarks)
- \`KafkaClient::fetch_all_watermarks\` (sequential, dead)
- \`KafkaClient::fetch_all_watermarks_parallel\` (per-partition fan-out with semaphore)
- \`KafkaClient::list_consumer_group_offsets\` (single-group FFI, replaced by batched)
- \`parse_member_assignment\` (custom binary parser; member assignments now pre-parsed from \`rd_kafka_MemberAssignment_partitions\`)
- \`OffsetCollector::new\` / \`OffsetCollector::collect\` (legacy sequential collector)

Net: **+588 lines in admin.rs, −588 lines across client.rs/offset_collector.rs.**

## Not in this PR (planned in follow-up tiers)

- **Tier 2**: \`Arc<str>\` topic interning, metadata caching across cycles, longer-TTL compacted-topic cache, \`tokio\` blocking-pool cap, opt-in member-assignment parsing
- **Tier 3**: Rate-based time-lag estimation, removal of \`TimestampConsumer\` pool (the biggest remaining memory consumer on large clusters)
- **Tier 4**: Frequency-tiered collection (hot / warm / cold), streaming result processing

## Test plan

- [x] \`cargo build --release\` — exit 0
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — exit 0
- [x] \`cargo test\` — 51/51 pass, exit 0
- [x] \`cargo fmt --check\` — exit 0
- [x] Local smoke test against \`test-stack/\` — metrics populated, no errors/warnings, poll_time_ms ~6ms
- [ ] **Needed**: run against real large cluster matching #61's size (7K topics / 19K partitions / 4K groups). Capture cycle elapsed_ms + RSS before/after.

## Review pointers

- **\`src/kafka/admin.rs\`** — the new FFI. All \`unsafe\` is here; RAII cleanup on every exit path mirrors the existing \`list_consumer_group_offsets\` wrapper from #57.
- **\`src/collector/offset_collector.rs::collect_parallel\`** — new orchestrated hot path driven from a single filtered topic set.
- **\`src/kafka/client.rs::fetch_watermarks_for_partitions\`** — new watermark entry point wrapping the batched FFI.
- **\`src/kafka/client.rs::fetch_compacted_topics_for\`** — now takes an explicit topic-name list (previously: full cluster).