### PR TITLE
perf: memory footprint reduction (Tier 2, addresses #61)

### DIFF
--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -391,7 +391,7 @@ impl ClusterManager {
                 Ok(Ok(((group_id, tp), Ok(None)))) => {
                     debug!(
                         group = group_id,
-                        topic = tp.topic,
+                        topic = %tp.topic,
                         partition = tp.partition,
                         "No timestamp available"
                     );
@@ -399,7 +399,7 @@ impl ClusterManager {
                 Ok(Ok(((group_id, tp), Err(e)))) => {
                     warn!(
                         group = group_id,
-                        topic = tp.topic,
+                        topic = %tp.topic,
                         partition = tp.partition,
                         error = %e,
                         "Failed to fetch timestamp"

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -45,8 +45,12 @@ impl ClusterManager {
         let performance = exporter_config.performance.clone();
 
         let client = Arc::new(KafkaClient::with_performance(&config, performance.clone())?);
-        let offset_collector =
-            OffsetCollector::with_performance(Arc::clone(&client), filters, performance.clone());
+        let offset_collector = OffsetCollector::with_performance(
+            Arc::clone(&client),
+            filters,
+            performance.clone(),
+            exporter_config.granularity,
+        );
 
         let timestamp_sampler = if exporter_config.timestamp_sampling.enabled {
             let ts_consumer = TimestampConsumer::with_pool_size(

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -118,7 +118,7 @@ impl LagCalculator {
             .iter()
             .map(|(tp, (low, high))| PartitionOffsetMetric {
                 cluster_name: snapshot.cluster_name.clone(),
-                topic: tp.topic.clone(),
+                topic: tp.topic.to_string(),
                 partition: tp.partition,
                 earliest_offset: *low,
                 latest_offset: *high,
@@ -181,13 +181,15 @@ impl LagCalculator {
                 } else {
                     Some(0.0)
                 };
-                // Compaction detected if topic has cleanup.policy=compact
-                let compaction_detected = compacted_topics.contains(&tp.topic);
+                // Compaction detected if topic has cleanup.policy=compact.
+                // `compacted_topics` is a HashSet<String>; deref the Arc<str>
+                // to &str so the lookup uses str's Hash/Eq.
+                let compaction_detected = compacted_topics.contains(&*tp.topic);
 
                 partition_metrics.push(PartitionLagMetric {
                     cluster_name: snapshot.cluster_name.clone(),
                     group_id: group.group_id.clone(),
-                    topic: tp.topic.clone(),
+                    topic: tp.topic.to_string(),
                     partition: tp.partition,
                     member_host,
                     consumer_id,
@@ -215,7 +217,7 @@ impl LagCalculator {
                         Some(group_max_lag_seconds.map_or(secs, |current| current.max(secs)));
                 }
 
-                *topic_lags.entry(tp.topic.clone()).or_insert(0) += lag;
+                *topic_lags.entry(tp.topic.to_string()).or_insert(0) += lag;
             }
 
             // Add group-level metrics

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -1,4 +1,4 @@
-use crate::config::{CompiledFilters, PerformanceConfig};
+use crate::config::{CompiledFilters, Granularity, PerformanceConfig};
 use crate::error::Result;
 use crate::kafka::client::{KafkaClient, TopicPartition};
 use std::collections::{HashMap, HashSet};
@@ -10,6 +10,7 @@ pub struct OffsetCollector {
     client: Arc<KafkaClient>,
     filters: CompiledFilters,
     performance: PerformanceConfig,
+    granularity: Granularity,
 }
 
 #[derive(Debug, Clone)]
@@ -47,11 +48,13 @@ impl OffsetCollector {
         client: Arc<KafkaClient>,
         filters: CompiledFilters,
         performance: PerformanceConfig,
+        granularity: Granularity,
     ) -> Self {
         Self {
             client,
             filters,
             performance,
+            granularity,
         }
     }
 
@@ -94,8 +97,13 @@ impl OffsetCollector {
             .map(|g| g.group_id.as_str())
             .collect();
 
-        // Describe filtered groups via batched FFI (one chunked call).
-        let descriptions = self.client.describe_consumer_groups(&group_ids)?;
+        // Describe filtered groups via batched FFI. Skip member-assignment
+        // parsing unless we actually emit per-partition member labels
+        // (granularity = partition).
+        let parse_assignments = matches!(self.granularity, Granularity::Partition);
+        let descriptions = self
+            .client
+            .describe_consumer_groups(&group_ids, parse_assignments)?;
 
         // Compute the monitored partition + topic set once from a single
         // metadata fetch. Topic filter is applied here, BEFORE any

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -70,12 +70,61 @@ impl CompactedTopicsCache {
     }
 }
 
+/// Shared handle to the filtered monitored-topic set. Arc-wrapped so cache
+/// hits are cheap pointer bumps rather than Vec clones.
+type MonitoredSet = (Arc<Vec<TopicPartition>>, Arc<Vec<String>>);
+
+/// Cached result of `list_monitored_partitions`. Re-fetching cluster metadata
+/// and re-running the topic filter is expensive on large clusters (thousands
+/// of topics), and the result is stable across many poll cycles. A fresh
+/// cache entry lets the collector skip both.
+struct MetadataCache {
+    ttl: Duration,
+    entry: Mutex<Option<(MonitoredSet, Instant)>>,
+}
+
+impl MetadataCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entry: Mutex::new(None),
+        }
+    }
+
+    fn get(&self) -> Option<MonitoredSet> {
+        if self.ttl.is_zero() {
+            return None;
+        }
+        let guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+        let (set, at) = guard.as_ref()?;
+        if at.elapsed() < self.ttl {
+            Some((Arc::clone(&set.0), Arc::clone(&set.1)))
+        } else {
+            None
+        }
+    }
+
+    /// Store fresh values and return Arc clones. When `ttl == 0` the cache
+    /// is treated as disabled: we don't store the entry (so subsequent
+    /// `get()` calls still return None) but we still wrap in Arcs for a
+    /// uniform return shape.
+    fn set(&self, partitions: Vec<TopicPartition>, topics: Vec<String>) -> MonitoredSet {
+        let set: MonitoredSet = (Arc::new(partitions), Arc::new(topics));
+        if !self.ttl.is_zero() {
+            let mut guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+            *guard = Some(((Arc::clone(&set.0), Arc::clone(&set.1)), Instant::now()));
+        }
+        set
+    }
+}
+
 pub struct OffsetCollector {
     client: Arc<KafkaClient>,
     filters: CompiledFilters,
     performance: PerformanceConfig,
     granularity: Granularity,
     compacted_cache: CompactedTopicsCache,
+    metadata_cache: MetadataCache,
 }
 
 #[derive(Debug, Clone)]
@@ -116,12 +165,14 @@ impl OffsetCollector {
         granularity: Granularity,
     ) -> Self {
         let compacted_cache = CompactedTopicsCache::new(performance.compacted_topics_cache_ttl);
+        let metadata_cache = MetadataCache::new(performance.metadata_cache_ttl);
         Self {
             client,
             filters,
             performance,
             granularity,
             compacted_cache,
+            metadata_cache,
         }
     }
 
@@ -292,7 +343,17 @@ impl OffsetCollector {
     /// Compute the partition list this collector should monitor by applying
     /// the topic whitelist/blacklist to the current cluster metadata. Runs
     /// before any partition-touching Admin API call.
-    fn list_monitored_partitions(&self) -> Result<(Vec<TopicPartition>, Vec<String>)> {
+    ///
+    /// Result is TTL-cached; a cache hit returns the previously computed
+    /// (partitions, topics) pair via cheap Arc clones. This avoids both the
+    /// `fetch_metadata` round trip and the O(topics) regex-filter pass on
+    /// every cycle.
+    fn list_monitored_partitions(&self) -> Result<MonitoredSet> {
+        if let Some(cached) = self.metadata_cache.get() {
+            debug!("Metadata cache hit");
+            return Ok(cached);
+        }
+
         let metadata = self.client.fetch_metadata()?;
         let mut partitions = Vec::new();
         let mut topics = Vec::new();
@@ -306,7 +367,7 @@ impl OffsetCollector {
                 partitions.push(TopicPartition::new(name, p.id()));
             }
         }
-        Ok((partitions, topics))
+        Ok(self.metadata_cache.set(partitions, topics))
     }
 
     /// Fetch offsets for all groups via batched Admin API.
@@ -503,6 +564,39 @@ mod tests {
         let (cached, to_fetch) = cache.partition(&topics);
         assert!(cached.is_empty());
         assert_eq!(to_fetch, vec!["a"]);
+    }
+
+    #[test]
+    fn metadata_cache_hit_returns_cached() {
+        let cache = MetadataCache::new(Duration::from_secs(60));
+        assert!(cache.get().is_none(), "empty cache should miss");
+
+        let (parts, topics) = cache.set(vec![TopicPartition::new("t", 0)], vec!["t".to_string()]);
+        assert_eq!(parts.len(), 1);
+        assert_eq!(topics.len(), 1);
+
+        let cached = cache.get().expect("cache should be populated");
+        assert_eq!(cached.0.len(), 1);
+        assert_eq!(cached.1.len(), 1);
+    }
+
+    #[test]
+    fn metadata_cache_disabled_by_zero_ttl() {
+        let cache = MetadataCache::new(Duration::ZERO);
+        let (_parts, _topics) = cache.set(vec![TopicPartition::new("t", 0)], vec!["t".into()]);
+        assert!(
+            cache.get().is_none(),
+            "zero-TTL cache must never return a hit"
+        );
+    }
+
+    #[test]
+    fn metadata_cache_expires() {
+        let cache = MetadataCache::new(Duration::from_millis(50));
+        cache.set(vec![], vec![]);
+        assert!(cache.get().is_some());
+        std::thread::sleep(Duration::from_millis(70));
+        assert!(cache.get().is_none(), "expired entry must miss");
     }
 
     #[test]

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -2,15 +2,80 @@ use crate::config::{CompiledFilters, Granularity, PerformanceConfig};
 use crate::error::Result;
 use crate::kafka::client::{KafkaClient, TopicPartition};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, instrument, warn};
+
+/// Per-topic TTL cache for `cleanup.policy=compact` detection.
+///
+/// `cleanup.policy` is set at topic creation and almost never changes, so
+/// caching it with a long TTL saves a per-cycle `DescribeConfigs` over the
+/// monitored topic set. On each cycle the collector asks the cache which
+/// topics still need to be queried fresh, then merges the cached-true
+/// entries with whatever DescribeConfigs returns.
+struct CompactedTopicsCache {
+    ttl: Duration,
+    // (is_compacted, fetched_at). Mutex is fine — accessed only from
+    // `collect_parallel` on the cluster's single collection task.
+    entries: Mutex<HashMap<String, (bool, Instant)>>,
+}
+
+impl CompactedTopicsCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Split `monitored_topics` into:
+    ///   - `cached_compacted` — topics the cache says are compacted (fresh)
+    ///   - `to_fetch` — topics with no fresh cache entry (need DescribeConfigs)
+    fn partition<'a>(&self, monitored_topics: &'a [String]) -> (HashSet<String>, Vec<&'a str>) {
+        let now = Instant::now();
+        let entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+
+        let mut cached_compacted = HashSet::new();
+        let mut to_fetch: Vec<&str> = Vec::new();
+        for topic in monitored_topics {
+            match entries.get(topic) {
+                Some((is_compacted, fetched_at)) if now.duration_since(*fetched_at) < self.ttl => {
+                    if *is_compacted {
+                        cached_compacted.insert(topic.clone());
+                    }
+                }
+                _ => to_fetch.push(topic.as_str()),
+            }
+        }
+        (cached_compacted, to_fetch)
+    }
+
+    /// Update the cache with a fresh `DescribeConfigs` result. For each topic
+    /// in `fetched_topics`, record whether it appeared in `compacted_result`.
+    fn update(&self, fetched_topics: &[&str], compacted_result: &HashSet<String>) {
+        let now = Instant::now();
+        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        for topic in fetched_topics {
+            let is_compacted = compacted_result.contains(*topic);
+            entries.insert((*topic).to_string(), (is_compacted, now));
+        }
+    }
+
+    /// Drop cache entries for topics no longer being monitored.
+    fn prune_to(&self, monitored_topics: &[String]) {
+        let keep: HashSet<&str> = monitored_topics.iter().map(|s| s.as_str()).collect();
+        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        entries.retain(|k, _| keep.contains(k.as_str()));
+    }
+}
 
 pub struct OffsetCollector {
     client: Arc<KafkaClient>,
     filters: CompiledFilters,
     performance: PerformanceConfig,
     granularity: Granularity,
+    compacted_cache: CompactedTopicsCache,
 }
 
 #[derive(Debug, Clone)]
@@ -50,11 +115,13 @@ impl OffsetCollector {
         performance: PerformanceConfig,
         granularity: Granularity,
     ) -> Self {
+        let compacted_cache = CompactedTopicsCache::new(performance.compacted_topics_cache_ttl);
         Self {
             client,
             filters,
             performance,
             granularity,
+            compacted_cache,
         }
     }
 
@@ -141,16 +208,37 @@ impl OffsetCollector {
         // group; we then filter the (much smaller) response by topic.
         let group_offsets = self.fetch_all_group_offsets_batched(&group_ids).await;
 
-        // Compacted-topic lookup restricted to monitored topics (huge saving
-        // vs. the prior full-cluster DescribeConfigs).
-        let compacted_topics = self
-            .client
-            .fetch_compacted_topics_for(&monitored_topics)
-            .await
-            .unwrap_or_else(|e| {
-                warn!(error = %e, "Failed to fetch compacted topics");
-                HashSet::new()
-            });
+        // Compacted-topic lookup — TTL-cached per topic. `cleanup.policy`
+        // almost never changes after topic creation, so most cycles only
+        // refresh new topics (or nothing at all in steady state).
+        let (mut compacted_topics, to_fetch) = self.compacted_cache.partition(&monitored_topics);
+        if !to_fetch.is_empty() {
+            debug!(
+                to_fetch = to_fetch.len(),
+                cached = compacted_topics.len(),
+                "Compacted-topic cache partial miss — refreshing"
+            );
+            let to_fetch_owned: Vec<String> = to_fetch.iter().map(|s| s.to_string()).collect();
+            match self
+                .client
+                .fetch_compacted_topics_for(&to_fetch_owned)
+                .await
+            {
+                Ok(freshly_compacted) => {
+                    self.compacted_cache.update(&to_fetch, &freshly_compacted);
+                    compacted_topics.extend(freshly_compacted);
+                }
+                Err(e) => warn!(error = %e, "Failed to refresh compacted topics"),
+            }
+        } else {
+            debug!(
+                cached = compacted_topics.len(),
+                "Compacted-topic cache fully hit — no DescribeConfigs RPC"
+            );
+        }
+        // Drop cache entries for topics no longer monitored (filter change,
+        // topic deletion) so memory doesn't grow unboundedly.
+        self.compacted_cache.prune_to(&monitored_topics);
 
         // Build group snapshots
         let mut groups = Vec::with_capacity(descriptions.len());
@@ -361,5 +449,77 @@ mod tests {
         assert_eq!(groups.len(), 2);
         assert!(groups.contains(&"group1"));
         assert!(groups.contains(&"group2"));
+    }
+
+    #[test]
+    fn compacted_cache_empty_cache_requests_all() {
+        let cache = CompactedTopicsCache::new(Duration::from_secs(60));
+        let topics = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let (cached, to_fetch) = cache.partition(&topics);
+        assert!(cached.is_empty());
+        assert_eq!(to_fetch, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn compacted_cache_hit_skips_fetch() {
+        let cache = CompactedTopicsCache::new(Duration::from_secs(60));
+        let topics = vec!["a".to_string(), "b".to_string()];
+        let mut compacted = HashSet::new();
+        compacted.insert("a".to_string());
+
+        // First partition call: everything needs fetching.
+        let (_cached, to_fetch) = cache.partition(&topics);
+        assert_eq!(to_fetch.len(), 2);
+
+        // Update with the fetch result.
+        cache.update(&to_fetch, &compacted);
+
+        // Second partition call: everything cached.
+        let (cached, to_fetch) = cache.partition(&topics);
+        assert_eq!(to_fetch.len(), 0);
+        assert_eq!(cached.len(), 1);
+        assert!(cached.contains("a"));
+    }
+
+    #[test]
+    fn compacted_cache_expired_entries_re_fetched() {
+        let cache = CompactedTopicsCache::new(Duration::from_millis(50));
+        let topics = vec!["a".to_string()];
+        let mut compacted = HashSet::new();
+        compacted.insert("a".to_string());
+
+        let (_cached, to_fetch) = cache.partition(&topics);
+        cache.update(&to_fetch, &compacted);
+
+        // Cached entry is fresh.
+        let (cached, to_fetch) = cache.partition(&topics);
+        assert!(cached.contains("a"));
+        assert!(to_fetch.is_empty());
+
+        // Wait for TTL to expire.
+        std::thread::sleep(Duration::from_millis(70));
+
+        // Cached entry is stale — partition() returns it for re-fetching.
+        let (cached, to_fetch) = cache.partition(&topics);
+        assert!(cached.is_empty());
+        assert_eq!(to_fetch, vec!["a"]);
+    }
+
+    #[test]
+    fn compacted_cache_prune_removes_unseen_topics() {
+        let cache = CompactedTopicsCache::new(Duration::from_secs(60));
+        let initial = vec!["a".to_string(), "b".to_string()];
+        let mut compacted = HashSet::new();
+        compacted.insert("a".to_string());
+        let (_cached, to_fetch) = cache.partition(&initial);
+        cache.update(&to_fetch, &compacted);
+
+        // Only "a" is still monitored. "b"'s cache entry should be dropped.
+        let remaining = vec!["a".to_string()];
+        cache.prune_to(&remaining);
+
+        let entries = cache.entries.lock().unwrap();
+        assert!(entries.contains_key("a"));
+        assert!(!entries.contains_key("b"));
     }
 }

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -363,8 +363,13 @@ impl OffsetCollector {
                 continue;
             }
             topics.push(name.to_string());
+            // Intern the topic name once per topic so the per-partition
+            // TopicPartition entries share one Arc<str> allocation. On a
+            // cluster with avg 10 partitions/topic this cuts topic-name
+            // heap allocs by 90%.
+            let topic_arc: Arc<str> = Arc::from(name);
             for p in topic.partitions() {
-                partitions.push(TopicPartition::new(name, p.id()));
+                partitions.push(TopicPartition::new(Arc::clone(&topic_arc), p.id()));
             }
         }
         Ok(self.metadata_cache.set(partitions, topics))

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,16 @@ pub struct PerformanceConfig {
     /// Set to 0 to disable. Default: 50 (~25 min at 30s poll interval).
     #[serde(default = "default_client_recycle_interval")]
     pub client_recycle_interval: u64,
+    /// Maximum size of the Tokio blocking-thread pool used for librdkafka FFI
+    /// calls. The default Tokio limit is 512; each thread holds a native
+    /// stack (2–8 MB depending on platform), so the worst-case virtual
+    /// memory footprint is significant on large clusters. 64 is ample for
+    /// this exporter: the hot path's concurrent blocking calls are bounded
+    /// by `max_concurrent_groups` + a few for watermark / compacted-topic /
+    /// timestamp-sampling FFI calls. Raise this if you set
+    /// `max_concurrent_groups` above ~50.
+    #[serde(default = "default_max_blocking_threads")]
+    pub max_blocking_threads: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -183,6 +193,10 @@ fn default_client_recycle_interval() -> u64 {
     50
 }
 
+fn default_max_blocking_threads() -> usize {
+    64
+}
+
 fn default_otel_endpoint() -> String {
     "http://localhost:4317".to_string()
 }
@@ -261,6 +275,7 @@ impl Default for PerformanceConfig {
             max_concurrent_groups: default_max_concurrent_groups(),
             max_concurrent_watermarks: default_max_concurrent_watermarks(),
             client_recycle_interval: default_client_recycle_interval(),
+            max_blocking_threads: default_max_blocking_threads(),
         }
     }
 }
@@ -321,6 +336,25 @@ impl Config {
             return Err(KlagError::Config(
                 "performance.max_concurrent_watermarks must be at least 1".to_string(),
             ));
+        }
+        // The blocking-thread pool must be able to hold every concurrent FFI
+        // call our hot path spawns simultaneously. `max_concurrent_groups`
+        // is the dominant consumer; the timestamp sampler adds up to
+        // `max_concurrent_fetches` more. If the pool is too small, tasks
+        // queue behind each other and we effectively serialize — silently
+        // undoing the Tier 1 win.
+        let min_needed = self.exporter.performance.max_concurrent_groups
+            + self.exporter.timestamp_sampling.max_concurrent_fetches
+            + 4; // small headroom for watermark / compacted-topic / metadata FFI
+        if self.exporter.performance.max_blocking_threads < min_needed {
+            return Err(KlagError::Config(format!(
+                "performance.max_blocking_threads ({}) must be >= max_concurrent_groups ({}) + \
+                 timestamp_sampling.max_concurrent_fetches ({}) + 4 = {}",
+                self.exporter.performance.max_blocking_threads,
+                self.exporter.performance.max_concurrent_groups,
+                self.exporter.timestamp_sampling.max_concurrent_fetches,
+                min_needed,
+            )));
         }
 
         Ok(())
@@ -584,6 +618,7 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(config.exporter.performance.max_concurrent_groups, 10);
         assert_eq!(config.exporter.performance.max_concurrent_watermarks, 50);
         assert_eq!(config.exporter.performance.client_recycle_interval, 50);
+        assert_eq!(config.exporter.performance.max_blocking_threads, 64);
     }
 
     #[test]
@@ -619,6 +654,55 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(config.exporter.performance.max_concurrent_groups, 20);
         assert_eq!(config.exporter.performance.max_concurrent_watermarks, 100);
         assert_eq!(config.exporter.performance.client_recycle_interval, 0);
+    }
+
+    #[test]
+    fn test_max_blocking_threads_rejected_when_too_small() {
+        // default max_concurrent_groups=10, max_concurrent_fetches=5,
+        // so minimum blocking threads = 10 + 5 + 4 = 19. 16 must fail.
+        let config_content = r#"
+[exporter]
+
+[exporter.performance]
+max_blocking_threads = 16
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("max_blocking_threads (16)"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains("= 19"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_max_blocking_threads_custom_value_accepted() {
+        let config_content = r#"
+[exporter]
+
+[exporter.performance]
+max_concurrent_groups = 30
+max_blocking_threads = 128
+
+[exporter.timestamp_sampling]
+max_concurrent_fetches = 20
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let config = Config::load(Some(file.path().to_str().unwrap())).unwrap();
+        assert_eq!(config.exporter.performance.max_blocking_threads, 128);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,15 @@ pub struct PerformanceConfig {
         default = "default_compacted_topics_cache_ttl"
     )]
     pub compacted_topics_cache_ttl: Duration,
+    /// How long to cache the derived "monitored partitions + monitored topics"
+    /// set from cluster metadata. A cycle with a fresh cache entry skips the
+    /// `fetch_metadata` call and the regex filtering pass over every topic
+    /// name — significant savings on clusters with thousands of topics.
+    /// New topics (or partition additions) become visible at most this long
+    /// after they appear on the cluster. Set to 0 to disable the cache
+    /// (refresh every cycle).
+    #[serde(with = "humantime_serde", default = "default_metadata_cache_ttl")]
+    pub metadata_cache_ttl: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -211,6 +220,10 @@ fn default_compacted_topics_cache_ttl() -> Duration {
     Duration::from_secs(3600)
 }
 
+fn default_metadata_cache_ttl() -> Duration {
+    Duration::from_secs(300)
+}
+
 fn default_otel_endpoint() -> String {
     "http://localhost:4317".to_string()
 }
@@ -291,6 +304,7 @@ impl Default for PerformanceConfig {
             client_recycle_interval: default_client_recycle_interval(),
             max_blocking_threads: default_max_blocking_threads(),
             compacted_topics_cache_ttl: default_compacted_topics_cache_ttl(),
+            metadata_cache_ttl: default_metadata_cache_ttl(),
         }
     }
 }
@@ -637,6 +651,10 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(
             config.exporter.performance.compacted_topics_cache_ttl,
             Duration::from_secs(3600)
+        );
+        assert_eq!(
+            config.exporter.performance.metadata_cache_ttl,
+            Duration::from_secs(300)
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -369,19 +369,27 @@ impl Config {
         // The blocking-thread pool must be able to hold every concurrent FFI
         // call our hot path spawns simultaneously. `max_concurrent_groups`
         // is the dominant consumer; the timestamp sampler adds up to
-        // `max_concurrent_fetches` more. If the pool is too small, tasks
-        // queue behind each other and we effectively serialize — silently
-        // undoing the Tier 1 win.
-        let min_needed = self.exporter.performance.max_concurrent_groups
-            + self.exporter.timestamp_sampling.max_concurrent_fetches
-            + 4; // small headroom for watermark / compacted-topic / metadata FFI
+        // `max_concurrent_fetches` more — but only when sampling is enabled.
+        // If the pool is too small, tasks queue behind each other and we
+        // effectively serialize — silently undoing the Tier 1 win.
+        let sampler_contribution = if self.exporter.timestamp_sampling.enabled {
+            self.exporter.timestamp_sampling.max_concurrent_fetches
+        } else {
+            0
+        };
+        let min_needed = self.exporter.performance.max_concurrent_groups + sampler_contribution + 4; // small headroom for watermark / compacted-topic / metadata FFI
         if self.exporter.performance.max_blocking_threads < min_needed {
             return Err(KlagError::Config(format!(
                 "performance.max_blocking_threads ({}) must be >= max_concurrent_groups ({}) + \
-                 timestamp_sampling.max_concurrent_fetches ({}) + 4 = {}",
+                 timestamp_sampling.max_concurrent_fetches ({}, sampling {}) + 4 = {}",
                 self.exporter.performance.max_blocking_threads,
                 self.exporter.performance.max_concurrent_groups,
-                self.exporter.timestamp_sampling.max_concurrent_fetches,
+                sampler_contribution,
+                if self.exporter.timestamp_sampling.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
                 min_needed,
             )));
         }
@@ -717,6 +725,33 @@ bootstrap_servers = "localhost:9092"
             "unexpected error: {msg}"
         );
         assert!(msg.contains("= 19"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_max_blocking_threads_sampler_excluded_when_disabled() {
+        // Sampling disabled → sampler_contribution = 0. Required min becomes
+        // max_concurrent_groups (10 default) + 4 = 14. 16 must be accepted
+        // (would have been rejected with the old validation that always
+        // counted max_concurrent_fetches = 5).
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+enabled = false
+
+[exporter.performance]
+max_blocking_threads = 16
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let config = Config::load(Some(file.path().to_str().unwrap()))
+            .expect("should accept 16 when sampling is disabled");
+        assert_eq!(config.exporter.performance.max_blocking_threads, 16);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,16 @@ pub struct PerformanceConfig {
     /// `max_concurrent_groups` above ~50.
     #[serde(default = "default_max_blocking_threads")]
     pub max_blocking_threads: usize,
+    /// How long to cache each topic's `cleanup.policy` in memory.
+    /// `cleanup.policy` rarely changes after topic creation, so caching it
+    /// for a long time saves a per-cycle `DescribeConfigs` RPC over the
+    /// monitored topic set. Only topics new to the cache (or whose entry
+    /// has expired) get queried on a given cycle.
+    #[serde(
+        with = "humantime_serde",
+        default = "default_compacted_topics_cache_ttl"
+    )]
+    pub compacted_topics_cache_ttl: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -197,6 +207,10 @@ fn default_max_blocking_threads() -> usize {
     64
 }
 
+fn default_compacted_topics_cache_ttl() -> Duration {
+    Duration::from_secs(3600)
+}
+
 fn default_otel_endpoint() -> String {
     "http://localhost:4317".to_string()
 }
@@ -276,6 +290,7 @@ impl Default for PerformanceConfig {
             max_concurrent_watermarks: default_max_concurrent_watermarks(),
             client_recycle_interval: default_client_recycle_interval(),
             max_blocking_threads: default_max_blocking_threads(),
+            compacted_topics_cache_ttl: default_compacted_topics_cache_ttl(),
         }
     }
 }
@@ -619,6 +634,10 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(config.exporter.performance.max_concurrent_watermarks, 50);
         assert_eq!(config.exporter.performance.client_recycle_interval, 50);
         assert_eq!(config.exporter.performance.max_blocking_threads, 64);
+        assert_eq!(
+            config.exporter.performance.compacted_topics_cache_ttl,
+            Duration::from_secs(3600)
+        );
     }
 
     #[test]

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -19,8 +19,30 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, warn};
+
+/// Per-call topic-name interner: one `Arc<str>` allocation per unique topic,
+/// so sibling partitions of the same topic share storage in the result map.
+/// On large clusters the same batched `ListOffsets` result contains every
+/// partition on the cluster — without interning, 19K `Arc<str>` allocations
+/// are wasted on topic names that only have a few dozen unique values.
+#[derive(Default)]
+struct TopicInterner {
+    by_name: HashMap<String, Arc<str>>,
+}
+
+impl TopicInterner {
+    fn intern(&mut self, topic: &str) -> Arc<str> {
+        if let Some(a) = self.by_name.get(topic) {
+            return Arc::clone(a);
+        }
+        let a: Arc<str> = Arc::from(topic);
+        self.by_name.insert(topic.to_string(), Arc::clone(&a));
+        a
+    }
+}
 
 /// Offset spec for `list_offsets_batched` — mirrors `RD_KAFKA_OFFSET_SPEC_*`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,6 +227,8 @@ pub fn list_offsets_batched(
             return Ok(out);
         }
 
+        let mut interner = TopicInterner::default();
+
         for i in 0..n_infos {
             let info = *infos_ptr.add(i);
             let tp_ptr = rd_kafka_ListOffsetsResultInfo_topic_partition(info);
@@ -238,8 +262,12 @@ pub fn list_offsets_batched(
             if tp_ref.topic.is_null() {
                 continue;
             }
-            let topic = CStr::from_ptr(tp_ref.topic).to_string_lossy().to_string();
-            out.insert(TopicPartition::new(topic, tp_ref.partition), tp_ref.offset);
+            let topic_str = CStr::from_ptr(tp_ref.topic).to_string_lossy();
+            let topic_arc = interner.intern(topic_str.as_ref());
+            out.insert(
+                TopicPartition::new(topic_arc, tp_ref.partition),
+                tp_ref.offset,
+            );
         }
 
         debug!(
@@ -730,5 +758,15 @@ mod tests {
         // RD_KAFKA_OFFSET_SPEC_EARLIEST == -2, _LATEST == -1 (from rdkafka.h).
         assert_eq!(OffsetSpec::Earliest.as_c_value(), -2);
         assert_eq!(OffsetSpec::Latest.as_c_value(), -1);
+    }
+
+    #[test]
+    fn topic_interner_returns_same_arc_for_same_name() {
+        let mut interner = TopicInterner::default();
+        let a = interner.intern("foo");
+        let b = interner.intern("foo");
+        assert!(Arc::ptr_eq(&a, &b), "same topic must share the Arc");
+        let c = interner.intern("bar");
+        assert!(!Arc::ptr_eq(&a, &c));
     }
 }

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -28,18 +28,23 @@ use tracing::{debug, warn};
 /// On large clusters the same batched `ListOffsets` result contains every
 /// partition on the cluster — without interning, 19K `Arc<str>` allocations
 /// are wasted on topic names that only have a few dozen unique values.
+///
+/// The set is keyed directly by `Arc<str>`; `get_key_value(&str)` works
+/// because `Arc<T>: Borrow<T>`, so the lookup hashes the topic as a `str`
+/// but returns the existing `Arc<str>` key to clone. This keeps the
+/// allocation count at exactly one `Arc<str>` per unique topic.
 #[derive(Default)]
 struct TopicInterner {
-    by_name: HashMap<String, Arc<str>>,
+    by_name: HashMap<Arc<str>, ()>,
 }
 
 impl TopicInterner {
     fn intern(&mut self, topic: &str) -> Arc<str> {
-        if let Some(a) = self.by_name.get(topic) {
+        if let Some((a, ())) = self.by_name.get_key_value(topic) {
             return Arc::clone(a);
         }
         let a: Arc<str> = Arc::from(topic);
-        self.by_name.insert(topic.to_string(), Arc::clone(&a));
+        self.by_name.insert(Arc::clone(&a), ());
         a
     }
 }

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -274,11 +274,18 @@ pub struct BatchedMember {
 /// Chunks the input into sub-calls of at most `chunk_size` groups each and
 /// aggregates results. Per-group errors are logged at WARN and the group is
 /// omitted from the returned Vec.
+///
+/// When `parse_assignments = false`, each returned `BatchedMember` has an
+/// empty `assignments: Vec<TopicPartition>`. This skips a per-member
+/// iteration over the assignment's `rd_kafka_topic_partition_list_t` — the
+/// data is only consumed by per-partition metrics (granularity = "partition"),
+/// so it's pure wasted work at the default topic granularity.
 pub fn describe_consumer_groups_batched(
     admin: &AdminClient<DefaultClientContext>,
     group_ids: &[&str],
     timeout: Duration,
     chunk_size: usize,
+    parse_assignments: bool,
 ) -> Result<Vec<BatchedGroupDescription>> {
     if group_ids.is_empty() {
         return Ok(Vec::new());
@@ -286,7 +293,8 @@ pub fn describe_consumer_groups_batched(
     let chunk_size = chunk_size.max(1);
     let mut out = Vec::with_capacity(group_ids.len());
     for chunk in group_ids.chunks(chunk_size) {
-        let mut part = describe_consumer_groups_one_chunk(admin, chunk, timeout)?;
+        let mut part =
+            describe_consumer_groups_one_chunk(admin, chunk, timeout, parse_assignments)?;
         out.append(&mut part);
     }
     Ok(out)
@@ -296,6 +304,7 @@ fn describe_consumer_groups_one_chunk(
     admin: &AdminClient<DefaultClientContext>,
     group_ids: &[&str],
     timeout: Duration,
+    parse_assignments: bool,
 ) -> Result<Vec<BatchedGroupDescription>> {
     let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
     let rk = admin_native_ptr(admin);
@@ -436,19 +445,21 @@ fn describe_consumer_groups_one_chunk(
                 let client_id = ptr_to_string(rd_kafka_MemberDescription_client_id(member));
                 let client_host = ptr_to_string(rd_kafka_MemberDescription_host(member));
 
-                let assignment = rd_kafka_MemberDescription_assignment(member);
                 let mut assignments = Vec::new();
-                if !assignment.is_null() {
-                    let tpl_ptr = rd_kafka_MemberAssignment_partitions(assignment);
-                    if !tpl_ptr.is_null() {
-                        let tpl = &*tpl_ptr;
-                        for j in 0..tpl.cnt {
-                            let el = &*tpl.elems.add(j as usize);
-                            if el.topic.is_null() {
-                                continue;
+                if parse_assignments {
+                    let assignment = rd_kafka_MemberDescription_assignment(member);
+                    if !assignment.is_null() {
+                        let tpl_ptr = rd_kafka_MemberAssignment_partitions(assignment);
+                        if !tpl_ptr.is_null() {
+                            let tpl = &*tpl_ptr;
+                            for j in 0..tpl.cnt {
+                                let el = &*tpl.elems.add(j as usize);
+                                if el.topic.is_null() {
+                                    continue;
+                                }
+                                let topic = CStr::from_ptr(el.topic).to_string_lossy().to_string();
+                                assignments.push(TopicPartition::new(topic, el.partition));
                             }
-                            let topic = CStr::from_ptr(el.topic).to_string_lossy().to_string();
-                            assignments.push(TopicPartition::new(topic, el.partition));
                         }
                     }
                 }

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -195,12 +195,27 @@ impl KafkaClient {
     /// which dominated collection time on large clusters (O(groups) serial
     /// round trips). `protocol_type`/`protocol` fields are not populated — they
     /// are not consumed downstream (marked `#[allow(dead_code)]`).
+    /// Describe consumer groups via batched FFI. Pass `parse_assignments =
+    /// false` to skip the per-member assignment-parsing step (saves
+    /// O(groups × members × partitions-per-member) work per cycle). The
+    /// data is only consumed by per-partition metrics, so the default
+    /// topic-granularity mode should pass `false`.
     #[instrument(skip(self, group_ids), fields(cluster = %self.config.name, count = group_ids.len()))]
-    pub fn describe_consumer_groups(&self, group_ids: &[&str]) -> Result<Vec<GroupDescription>> {
+    pub fn describe_consumer_groups(
+        &self,
+        group_ids: &[&str],
+        parse_assignments: bool,
+    ) -> Result<Vec<GroupDescription>> {
         use crate::kafka::admin::describe_consumer_groups_batched;
 
         let admin = self.admin();
-        let batched = describe_consumer_groups_batched(&admin, group_ids, self.timeout, 100)?;
+        let batched = describe_consumer_groups_batched(
+            &admin,
+            group_ids,
+            self.timeout,
+            100,
+            parse_assignments,
+        )?;
 
         Ok(batched
             .into_iter()

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -13,12 +13,20 @@ use tracing::{debug, info, instrument, warn};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TopicPartition {
-    pub topic: String,
+    /// `Arc<str>` rather than `String` so multiple partitions of the same
+    /// topic can share one heap allocation for the topic name. On clusters
+    /// with many partitions per topic (and whenever a `HashMap<TopicPartition,
+    /// _>` is cloned) this meaningfully cuts heap churn.
+    pub topic: Arc<str>,
     pub partition: i32,
 }
 
 impl TopicPartition {
-    pub fn new(topic: impl Into<String>, partition: i32) -> Self {
+    /// Build a fresh `TopicPartition`. Accepts anything that can produce an
+    /// `Arc<str>`: `&str`, `String`, `Arc<str>`, `&Arc<str>`, etc. Callers
+    /// that already hold a shared `Arc<str>` (e.g., from a per-cycle topic
+    /// interner) should pass `Arc::clone(&shared)` to avoid a fresh alloc.
+    pub fn new(topic: impl Into<Arc<str>>, partition: i32) -> Self {
         Self {
             topic: topic.into(),
             partition,

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -161,7 +161,7 @@ impl TimestampConsumer {
                     let timestamp = msg.timestamp().to_millis();
 
                     debug!(
-                        topic = tp.topic,
+                        topic = %tp.topic,
                         partition = tp.partition,
                         requested_offset = offset,
                         actual_offset = msg.offset(),
@@ -173,7 +173,7 @@ impl TimestampConsumer {
                 }
                 Err(e) => {
                     warn!(
-                        topic = tp.topic,
+                        topic = %tp.topic,
                         partition = tp.partition,
                         error = %e,
                         "Failed to fetch message"
@@ -183,7 +183,7 @@ impl TimestampConsumer {
             },
             None => {
                 debug!(
-                    topic = tp.topic,
+                    topic = %tp.topic,
                     partition = tp.partition,
                     offset = offset,
                     "No message available at offset (may be beyond high watermark)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,7 @@ struct Args {
     log_level: String,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Initialize logging
@@ -59,14 +58,30 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Starting klag-exporter");
 
-    // Load configuration
+    // Load configuration before building the runtime — the blocking-thread
+    // pool size comes from config, and we want an early, clear error on
+    // config problems rather than a cryptic runtime-setup failure.
     let config = Config::load(Some(&args.config))?;
     info!(
         clusters = config.clusters.len(),
         poll_interval = ?config.exporter.poll_interval,
+        max_blocking_threads = config.exporter.performance.max_blocking_threads,
         "Configuration loaded"
     );
 
+    // Bound the tokio blocking-thread pool. The default (512) commits up to
+    // several GB of virtual memory just for native thread stacks; this
+    // exporter only needs enough threads to cover concurrent FFI calls from
+    // the collector + timestamp sampler.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .max_blocking_threads(config.exporter.performance.max_blocking_threads)
+        .build()?;
+
+    runtime.block_on(async_main(config))
+}
+
+async fn async_main(config: Config) -> anyhow::Result<()> {
     // Create shared metrics registry
     let registry = Arc::new(MetricsRegistry::new());
 


### PR DESCRIPTION
## Summary

Tier 2 of the memory/performance rework. Five targeted changes that reduce steady-state memory and per-cycle allocations after Tier 1 established the batched Admin API path.

## What changed

### T7 — Cap tokio blocking-thread pool (default 64)

The default tokio pool holds up to 512 threads; with per-thread native stacks (2–8 MB) this is several GB of virtual memory just for stacks. 64 is ample: the hot path's concurrent blocking FFI calls are bounded by \`max_concurrent_groups\` + \`max_concurrent_fetches\` + a few more.

- \`main()\` now builds the runtime manually via \`Builder::max_blocking_threads()\`
- Config: \`PerformanceConfig.max_blocking_threads\` (default 64)
- Validation rejects values too small to fit all concurrent FFI callers

### T9 — Skip member-assignment parsing at topic granularity

Member assignments are only surfaced as per-partition metric labels (member_host, consumer_id, client_id). At the default topic granularity they are parsed then thrown away — O(groups × members × partitions-per-member) of wasted FFI work per cycle.

- \`describe_consumer_groups_batched\` now takes \`parse_assignments: bool\`
- Collector passes \`matches!(granularity, Granularity::Partition)\`

### T5 — TTL cache for compacted-topic detection

\`cleanup.policy\` is set at topic creation and almost never changes. Querying it via \`DescribeConfigs\` against the full monitored topic set every cycle is wasted work — on a 7K-topic cluster this is the most expensive RPC that survived Tier 1.

- Per-topic cache with configurable TTL (default 1h)
- Only stale/new entries hit DescribeConfigs; in steady state, 0 RPC per cycle
- Prune entries for topics no longer monitored

### T8 — TTL cache for filtered monitored-topic set

Every cycle re-fetched cluster metadata and re-ran the topic whitelist/blacklist regex against every topic. Both are significant on large clusters.

- TTL-cached (default 5min). New topics / partition-count growth appear with up to one TTL of delay
- Arc-wrapped so cache hits are cheap pointer bumps rather than Vec clones — the Arc flows into \`spawn_blocking\` for the watermark fetch without deep-copying the 19K-entry partition list
- \`metadata_cache_ttl = 0\` disables

### T6 — Intern topic names as \`Arc<str>\`

\`TopicPartition.topic\` changes from \`String\` to \`Arc<str>\`, and the result-parsing loops of large FFI calls use a per-call \`TopicInterner\` so sibling partitions of the same topic share one allocation. Cloning a \`TopicPartition\` (or a \`HashMap<TopicPartition, _>\`) is now a cheap Arc bump.

## Cumulative effect after Tier 1 + Tier 2

Steady-state per-cycle work on a large cluster:

| Operation | Tier 0 (pre-Tier 1) | Tier 1 | After Tier 2 |
|---|---|---|---|
| DescribeConsumerGroups | 4,128 sequential RPCs | ~42 chunked | same |
| ListOffsets | 19,388 per-partition RPCs | 2 batched | same |
| ListConsumerGroupOffsets | 4,128 + 19K-partition-list clones | ~4,128 (NULL partitions) | same |
| DescribeConfigs (compacted) | full-cluster every cycle | full monitored-topic set every cycle | 0 in steady state |
| fetch_metadata + filter | full cluster every cycle | full cluster every cycle | cached 5min |
| Member assignments parse | every cycle | every cycle | only if granularity=partition |
| Blocking-thread stacks | up to ~4 GB virtual | same | capped (~256 MB for 64 threads × 8 MB/stack typical) |

## Not in this PR (deferred to Tier 3+)

- Tier 3: Rate-based time-lag estimation, removal of \`TimestampConsumer\` pool (the biggest remaining memory consumer on large clusters)
- Tier 4: Frequency-tiered collection, streaming result processing

## Test plan

- [x] \`cargo build --release\` — exit 0
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — exit 0
- [x] \`cargo test\` — 61/61 pass (new tests for blocking-pool validation, compacted-topic cache hit/expire/prune, metadata cache hit/disabled/expire, topic interner)
- [x] \`cargo fmt --check\` — exit 0
- [x] Local smoke test against \`test-stack/\`: no errors/warnings, metrics populated, \`max_blocking_threads=64\` logged at startup, cache-hit debug lines observed on cycles 2+
- [ ] **Needed**: run against a real large cluster and compare RSS + cycle elapsed_ms vs Tier 1

## Review pointers

- \`src/config.rs\` — two new performance knobs (\`max_blocking_threads\`, \`compacted_topics_cache_ttl\`, \`metadata_cache_ttl\`), startup validation
- \`src/main.rs\` — manual runtime builder replacing \`#[tokio::main]\`
- \`src/collector/offset_collector.rs\` — two new cache types (\`CompactedTopicsCache\`, \`MetadataCache\`), each with unit tests
- \`src/kafka/admin.rs\` — \`TopicInterner\` used in \`list_offsets_batched\`, \`parse_assignments\` flag on \`describe_consumer_groups_batched\`
- \`src/kafka/client.rs\` — \`TopicPartition.topic: Arc<str>\`