### PR TITLE
chore: release v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/softwaremill/klag-exporter/compare/v0.1.21...v0.1.22) - 2026-04-15
+
+### Added
+
+- switch time-lag default to rate-based estimation (Tier 3)
+- *(collector)* add RateSampler for rate-based time-lag estimation
+
+### Other
+
+- address Copilot PR feedback (Tier 4)
+- max_concurrent_watermarks (no-op since Tier 1 batched ListOffsets)
+- *(collector)* per-phase elapsed_ms in the cycle-complete debug log
+- *(collector)* TTL cache list_consumer_groups (default 60s)
+- *(kafka)* parallelize DescribeConsumerGroups chunks
+- address Copilot PR feedback (Tier 3)
+- *(readme)* document rate vs message time-lag modes
+- address Copilot PR feedback (Tier 2)
+- *(kafka)* intern topic names as Arc<str> with per-call dedup
+- *(collector)* add TTL cache for filtered monitored-topic set
+- *(collector)* add TTL cache for compacted-topic detection
+- *(kafka)* skip member-assignment parsing unless granularity=partition
+- *(runtime)* cap tokio blocking-thread pool (default 64)
+
 ## [0.1.21](https://github.com/softwaremill/klag-exporter/compare/v0.1.20...v0.1.21) - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "klag-exporter"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klag-exporter"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 description = "High-performance Kafka consumer group lag exporter with offset and time lag metrics"
 authors = ["Krzysztof Grajek"]

--- a/helm/klag-exporter/Chart.yaml
+++ b/helm/klag-exporter/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: "0.1.21"
+version: "0.1.22"
 
-appVersion: "0.1.21"
+appVersion: "0.1.22"

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/softwaremill/klag-exporter
   pullPolicy: IfNotPresent
-  tag: "0.1.21"
+  tag: "0.1.22"
 
 imagePullSecrets: []
 # This is to override the chart name.


### PR DESCRIPTION



## 🤖 New release

* `klag-exporter`: 0.1.21 -> 0.1.22

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.22](https://github.com/softwaremill/klag-exporter/compare/v0.1.21...v0.1.22) - 2026-04-15

### Added

- switch time-lag default to rate-based estimation (Tier 3)
- *(collector)* add RateSampler for rate-based time-lag estimation

### Other

- address Copilot PR feedback (Tier 4)
- max_concurrent_watermarks (no-op since Tier 1 batched ListOffsets)
- *(collector)* per-phase elapsed_ms in the cycle-complete debug log
- *(collector)* TTL cache list_consumer_groups (default 60s)
- *(kafka)* parallelize DescribeConsumerGroups chunks
- address Copilot PR feedback (Tier 3)
- *(readme)* document rate vs message time-lag modes
- address Copilot PR feedback (Tier 2)
- *(kafka)* intern topic names as Arc<str> with per-call dedup
- *(collector)* add TTL cache for filtered monitored-topic set
- *(collector)* add TTL cache for compacted-topic detection
- *(kafka)* skip member-assignment parsing unless granularity=partition
- *(runtime)* cap tokio blocking-thread pool (default 64)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).