### PR TITLE
perf: rate-based time-lag, remove consumer pool in default mode (Tier 3, addresses #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,27 @@ A high-performance Apache Kafka® consumer group lag exporter written in Rust. C
 - Shows 0 lag incorrectly for idle topics
 - Requires many poll cycles to build accurate tables
 
-**Our approach (targeted timestamp sampling):**
+**Our approach (two modes, default rate-based):**
 
-- Seeks directly to the consumer group's committed offset
-- Reads actual message timestamp — always accurate
+klag-exporter supports two time-lag strategies, selectable via `timestamp_sampling.mode`:
+
+#### `rate` mode (default since v0.2)
+
+- No consumer pool, no extra librdkafka clients — dramatically lower resident memory on large clusters
+- Keeps a short ring buffer of `(observation_time, high_watermark)` per partition
+- Rate = Δhigh_watermark / Δtime; `time_lag = (high_watermark − committed_offset) / rate`
+- Accurate for lag alerting (magnitude right); accuracy depends on steady producer rate across the history window
+- Returns no value (metric missing) on the first cycle after startup or topic creation (needs ≥ 2 samples) and on partitions producing below the configured floor
+
+#### `message` mode
+
+- Seeks directly to the consumer group's committed offset via a pooled BaseConsumer
+- Reads the actual message timestamp — exact
 - Handles idle producers correctly (shows true message age)
 - TTL-cached to prevent excessive broker load
+- Memory cost: each pooled BaseConsumer is a full librdkafka client (~5–15 MB) — keep `max_concurrent_fetches` small
+
+**When to choose which:** Rate is the right default for almost everyone. Pick message mode only if you have a regulatory / audit requirement for exact timestamps and your cluster is small enough that the consumer pool's memory overhead is acceptable.
 
 ### Compaction and Retention Limitations
 
@@ -222,6 +237,16 @@ granularity = "partition"  # "topic" or "partition"
 
 [exporter.timestamp_sampling]
 enabled = true
+# "rate" (default, recommended for large clusters) or "message".
+# See "Time Lag Modes" below for tradeoffs.
+mode = "rate"
+
+# Rate-mode tuning (only used when mode = "rate"):
+rate_history_samples = 5           # ring buffer size per partition
+rate_history_max_age = "10m"       # drop samples older than this
+rate_min_msgs_per_sec = 0.01       # below this rate → time lag reported as missing
+
+# Message-mode tuning (only used when mode = "message"):
 cache_ttl = "60s"
 max_concurrent_fetches = 10
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A high-performance Apache Kafka® consumer group lag exporter written in Rust. C
 
 klag-exporter supports two time-lag strategies, selectable via `timestamp_sampling.mode`:
 
-#### `rate` mode (default since v0.2)
+#### `rate` mode (default)
 
 - No consumer pool, no extra librdkafka clients — dramatically lower resident memory on large clusters
 - Keeps a short ring buffer of `(observation_time, high_watermark)` per partition

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -1,17 +1,16 @@
-use crate::collector::lag_calculator::{LagCalculator, TimestampData};
+use crate::collector::lag_calculator::LagCalculator;
 use crate::collector::offset_collector::OffsetCollector;
 use crate::collector::timestamp_sampler::TimestampSampler;
 use crate::config::{ClusterConfig, ExporterConfig, Granularity};
 use crate::error::Result;
-use crate::kafka::client::{KafkaClient, TopicPartition};
+use crate::kafka::client::KafkaClient;
 use crate::kafka::TimestampConsumer;
 use crate::leadership::LeadershipStatus;
 use crate::metrics::registry::MetricsRegistry;
-use futures::future::join_all;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::broadcast;
 use tracing::{debug, error, info, instrument, warn};
 
 /// Default timeout for a single collection cycle (should be less than poll_interval)
@@ -52,25 +51,37 @@ impl ClusterManager {
             exporter_config.granularity,
         );
 
-        let timestamp_sampler = if exporter_config.timestamp_sampling.enabled {
-            let ts_consumer = TimestampConsumer::with_pool_size(
-                &config,
-                exporter_config.timestamp_sampling.max_concurrent_fetches,
-            )?;
-            Some(TimestampSampler::new(
-                ts_consumer,
-                exporter_config.timestamp_sampling.cache_ttl,
-            ))
+        let ts_cfg = &exporter_config.timestamp_sampling;
+        let timestamp_sampler = if ts_cfg.enabled {
+            Some(match ts_cfg.mode {
+                crate::config::TimestampSamplingMode::Message => {
+                    // Only build the pool when actually using it. This is
+                    // the Tier-3 resident-memory saving for rate-mode users:
+                    // no BaseConsumer pool, no extra librdkafka clients.
+                    let ts_consumer =
+                        TimestampConsumer::with_pool_size(&config, ts_cfg.max_concurrent_fetches)?;
+                    TimestampSampler::new_message(ts_consumer, ts_cfg.cache_ttl)
+                }
+                crate::config::TimestampSamplingMode::Rate => {
+                    let rs = crate::collector::rate_sampler::RateSampler::new(
+                        ts_cfg.rate_history_samples,
+                        ts_cfg.rate_history_max_age,
+                        ts_cfg.rate_min_msgs_per_sec,
+                    );
+                    TimestampSampler::new_rate(rs)
+                }
+            })
         } else {
             None
         };
 
         info!(
             cluster = cluster_name,
-            timestamp_sampling = exporter_config.timestamp_sampling.enabled,
+            timestamp_sampling = ts_cfg.enabled,
+            timestamp_sampling_mode = ?ts_cfg.mode,
             poll_interval = ?exporter_config.poll_interval,
             granularity = ?exporter_config.granularity,
-            max_concurrent_fetches = exporter_config.timestamp_sampling.max_concurrent_fetches,
+            max_concurrent_fetches = ts_cfg.max_concurrent_fetches,
             custom_labels = ?cluster_labels,
             "Created cluster manager"
         );
@@ -268,18 +279,22 @@ impl ClusterManager {
             "Collected offsets"
         );
 
-        // Collect timestamps if enabled (with concurrency limit)
-        let timestamps = if let Some(ref sampler) = self.timestamp_sampler {
-            self.collect_timestamps_concurrent(sampler, &snapshot).await
-        } else {
-            HashMap::new()
-        };
-
-        // Calculate lag metrics
+        // Calculate lag metrics: compute "now" BEFORE time-lag computation
+        // because rate mode synthesizes timestamps relative to `now_ms`.
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_millis() as i64;
+
+        // Compute per-partition time lags via whichever sampler mode is
+        // configured (rate = no I/O, message = bounded concurrent FFI).
+        let timestamps = if let Some(ref sampler) = self.timestamp_sampler {
+            sampler
+                .compute_time_lags(&snapshot, now_ms, self.max_concurrent_fetches)
+                .await
+        } else {
+            HashMap::new()
+        };
 
         let poll_time_ms = start.elapsed().as_millis() as u64;
         let lag_metrics = LagCalculator::calculate(
@@ -310,111 +325,6 @@ impl ClusterManager {
         );
 
         Ok(())
-    }
-
-    async fn collect_timestamps_concurrent(
-        &self,
-        sampler: &TimestampSampler,
-        snapshot: &crate::collector::offset_collector::OffsetsSnapshot,
-    ) -> HashMap<(String, TopicPartition), TimestampData> {
-        // Build list of requests for partitions with lag
-        let mut requests: Vec<(String, TopicPartition, i64)> = Vec::new();
-
-        for group in &snapshot.groups {
-            for (tp, committed_offset) in &group.offsets {
-                let high_watermark = snapshot.get_high_watermark(tp).unwrap_or(*committed_offset);
-                let lag = high_watermark - committed_offset;
-
-                if lag > 0 {
-                    requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
-                }
-            }
-        }
-
-        if requests.is_empty() {
-            return HashMap::new();
-        }
-
-        debug!(
-            cluster = %self.cluster_name,
-            request_count = requests.len(),
-            max_concurrent = self.max_concurrent_fetches,
-            "Fetching timestamps in parallel"
-        );
-
-        // Use semaphore to limit concurrency
-        let semaphore = Arc::new(Semaphore::new(self.max_concurrent_fetches));
-        let mut handles = Vec::with_capacity(requests.len());
-
-        // Spawn tasks with proper semaphore-based backpressure
-        for (group_id, tp, offset) in requests {
-            let semaphore_clone = semaphore.clone();
-            let sampler_clone = sampler.clone();
-
-            // Spawn an async task that properly acquires the semaphore before spawning blocking work
-            let handle = tokio::spawn(async move {
-                // Acquire permit - this properly awaits until one is available
-                let permit: OwnedSemaphorePermit = semaphore_clone
-                    .acquire_owned()
-                    .await
-                    .expect("semaphore closed");
-
-                // Now spawn the blocking task with the permit held
-                let result = tokio::task::spawn_blocking(move || {
-                    let _permit = permit; // Hold permit until blocking work completes
-                    let result = sampler_clone.get_timestamp(&group_id, &tp, offset);
-                    ((group_id, tp), result)
-                })
-                .await;
-
-                result
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for all tasks to complete in parallel
-        let results = join_all(handles).await;
-
-        // Collect results (nested Result from tokio::spawn -> spawn_blocking)
-        let mut timestamps = HashMap::new();
-        for result in results {
-            match result {
-                Ok(Ok(((group_id, tp), Ok(Some(ts_result))))) => {
-                    timestamps.insert(
-                        (group_id, tp),
-                        TimestampData {
-                            timestamp_ms: ts_result.timestamp_ms,
-                        },
-                    );
-                }
-                Ok(Ok(((group_id, tp), Ok(None)))) => {
-                    debug!(
-                        group = group_id,
-                        topic = %tp.topic,
-                        partition = tp.partition,
-                        "No timestamp available"
-                    );
-                }
-                Ok(Ok(((group_id, tp), Err(e)))) => {
-                    warn!(
-                        group = group_id,
-                        topic = %tp.topic,
-                        partition = tp.partition,
-                        error = %e,
-                        "Failed to fetch timestamp"
-                    );
-                }
-                Ok(Err(e)) => {
-                    warn!(error = %e, "Timestamp fetch blocking task panicked");
-                }
-                Err(e) => {
-                    warn!(error = %e, "Timestamp fetch task panicked");
-                }
-            }
-        }
-
-        timestamps
     }
 }
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,3 +1,4 @@
 pub mod lag_calculator;
 pub mod offset_collector;
+pub mod rate_sampler;
 pub mod timestamp_sampler;

--- a/src/collector/rate_sampler.rs
+++ b/src/collector/rate_sampler.rs
@@ -1,0 +1,243 @@
+//! Rate-based time-lag estimation.
+//!
+//! The classic way to compute per-partition time-lag is to read the message
+//! at the consumer's committed offset and subtract its produce timestamp from
+//! "now". That works but it scales poorly on large clusters: every laggy
+//! partition requires a full `assign()` + `poll()` round trip through a
+//! librdkafka BaseConsumer, and the consumer pool itself occupies tens to
+//! hundreds of MB of resident memory (each `BaseConsumer` is a full
+//! librdkafka client with its own metadata cache and background threads).
+//!
+//! Rate-based estimation avoids the pool entirely. For each partition we
+//! keep a short ring buffer of `(observation_time, high_watermark)` samples
+//! taken at each collection cycle. The broker's production rate is then
+//! `Δhigh_watermark / Δtime`, and the estimated time lag for a consumer at
+//! committed offset `C` with high watermark `H` is `(H - C) / rate`.
+//!
+//! Accuracy: this assumes the producer's rate has been steady over the
+//! history window. In practice that's good enough for lag alerting — alerts
+//! care about magnitude (minutes vs. hours), not precision. When rate is
+//! below a configurable floor or history is insufficient, we return `None`
+//! and the metric is omitted, matching the behavior of the message-read mode
+//! when a broker error prevents a fetch.
+
+use crate::kafka::client::TopicPartition;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy)]
+struct WatermarkSample {
+    at: Instant,
+    hwm: i64,
+}
+
+pub struct RateSampler {
+    history: Mutex<HashMap<TopicPartition, VecDeque<WatermarkSample>>>,
+    /// Maximum samples kept per partition.
+    max_samples: usize,
+    /// Drop samples older than this during periodic pruning.
+    max_age: Duration,
+    /// Below this rate (messages/sec across the full history window) we
+    /// treat the estimate as unreliable and return None. Prevents dividing
+    /// by near-zero rates on idle partitions.
+    min_msgs_per_sec: f64,
+}
+
+impl RateSampler {
+    pub fn new(max_samples: usize, max_age: Duration, min_msgs_per_sec: f64) -> Self {
+        Self {
+            history: Mutex::new(HashMap::new()),
+            max_samples: max_samples.max(2),
+            max_age,
+            min_msgs_per_sec,
+        }
+    }
+
+    /// Record one high-watermark observation per partition. Call this once
+    /// per collection cycle, after watermarks have been fetched, before
+    /// calling [`estimate_lag_seconds`]. Also prunes entries for partitions
+    /// no longer present in `watermarks` (topic deleted / filter change).
+    pub fn record_watermarks(&self, watermarks: &HashMap<TopicPartition, (i64, i64)>) {
+        let now = Instant::now();
+        let mut history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Drop entries for partitions no longer being monitored.
+        history.retain(|tp, _| watermarks.contains_key(tp));
+
+        for (tp, (_low, high)) in watermarks {
+            let buf = history.entry(tp.clone()).or_default();
+            // Drop samples past max_age.
+            while let Some(front) = buf.front() {
+                if now.duration_since(front.at) > self.max_age {
+                    buf.pop_front();
+                } else {
+                    break;
+                }
+            }
+            buf.push_back(WatermarkSample { at: now, hwm: *high });
+            while buf.len() > self.max_samples {
+                buf.pop_front();
+            }
+        }
+    }
+
+    /// Return the estimated time lag in seconds, or `None` if the history
+    /// is insufficient or the rate is below the reliability floor.
+    pub fn estimate_lag_seconds(&self, tp: &TopicPartition, lag: i64) -> Option<f64> {
+        if lag <= 0 {
+            return Some(0.0);
+        }
+        let history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        let buf = history.get(tp)?;
+        if buf.len() < 2 {
+            return None;
+        }
+        let first = *buf.front()?;
+        let last = *buf.back()?;
+        let d_hwm = (last.hwm - first.hwm) as f64;
+        let d_t = last.at.saturating_duration_since(first.at).as_secs_f64();
+        if d_t <= 0.0 || d_hwm <= 0.0 {
+            return None;
+        }
+        let rate = d_hwm / d_t;
+        if rate < self.min_msgs_per_sec {
+            return None;
+        }
+        Some(lag as f64 / rate)
+    }
+
+    /// Current number of partitions with history entries. Used for
+    /// diagnostics / metrics.
+    pub fn tracked_partitions(&self) -> usize {
+        self.history
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .len()
+    }
+
+    /// Drop all history. Used when a cluster-wide reset is needed (e.g.
+    /// leadership lost) — currently not wired; stale history auto-recovers
+    /// because rate is computed from endpoints of the window.
+    #[allow(dead_code)]
+    pub fn clear(&self) {
+        self.history
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tp(topic: &str, partition: i32) -> TopicPartition {
+        TopicPartition::new(topic, partition)
+    }
+
+    #[test]
+    fn single_sample_returns_none() {
+        let s = RateSampler::new(5, Duration::from_secs(600), 0.01);
+        let mut wm = HashMap::new();
+        wm.insert(tp("t", 0), (0, 100));
+        s.record_watermarks(&wm);
+        assert_eq!(s.estimate_lag_seconds(&tp("t", 0), 50), None);
+    }
+
+    #[test]
+    fn two_samples_compute_rate() {
+        let s = RateSampler::new(5, Duration::from_secs(600), 0.01);
+
+        let mut wm1 = HashMap::new();
+        wm1.insert(tp("t", 0), (0, 100));
+        s.record_watermarks(&wm1);
+
+        // Simulate the passage of time by sleeping. For a real-time unit
+        // test this is the cleanest way to exercise the Instant math.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let mut wm2 = HashMap::new();
+        // 1000 new messages in ~100 ms = ~10,000 msgs/sec.
+        wm2.insert(tp("t", 0), (0, 1100));
+        s.record_watermarks(&wm2);
+
+        let est = s
+            .estimate_lag_seconds(&tp("t", 0), 500)
+            .expect("should compute rate");
+        // Expected: 500 msgs / 10,000 msgs/sec = 0.05s. Allow generous
+        // tolerance for CI jitter in the 100ms sleep.
+        assert!(
+            (0.02..0.2).contains(&est),
+            "est out of sanity range: {est}"
+        );
+    }
+
+    #[test]
+    fn zero_lag_is_zero_seconds() {
+        let s = RateSampler::new(5, Duration::from_secs(600), 0.01);
+        let mut wm = HashMap::new();
+        wm.insert(tp("t", 0), (0, 100));
+        s.record_watermarks(&wm);
+        assert_eq!(s.estimate_lag_seconds(&tp("t", 0), 0), Some(0.0));
+        // Even a single-sample partition returns Some(0.0) for zero lag.
+    }
+
+    #[test]
+    fn idle_partition_below_min_rate_returns_none() {
+        let s = RateSampler::new(5, Duration::from_secs(600), 100.0);
+
+        let mut wm1 = HashMap::new();
+        wm1.insert(tp("t", 0), (0, 100));
+        s.record_watermarks(&wm1);
+        std::thread::sleep(Duration::from_millis(50));
+        // hwm unchanged → rate = 0 → below floor → None.
+        s.record_watermarks(&wm1);
+
+        assert_eq!(s.estimate_lag_seconds(&tp("t", 0), 10), None);
+    }
+
+    #[test]
+    fn history_bounded_by_max_samples() {
+        let s = RateSampler::new(3, Duration::from_secs(600), 0.01);
+        let mut wm = HashMap::new();
+        wm.insert(tp("t", 0), (0, 0));
+        for i in 0..10 {
+            wm.insert(tp("t", 0), (0, i));
+            s.record_watermarks(&wm);
+        }
+        let history = s.history.lock().unwrap();
+        let buf = history.get(&tp("t", 0)).unwrap();
+        assert_eq!(buf.len(), 3, "must be bounded to max_samples");
+    }
+
+    #[test]
+    fn unmonitored_partitions_pruned() {
+        let s = RateSampler::new(5, Duration::from_secs(600), 0.01);
+        let mut wm = HashMap::new();
+        wm.insert(tp("t", 0), (0, 100));
+        wm.insert(tp("other", 0), (0, 100));
+        s.record_watermarks(&wm);
+        assert_eq!(s.tracked_partitions(), 2);
+
+        let mut wm2 = HashMap::new();
+        wm2.insert(tp("t", 0), (0, 101));
+        s.record_watermarks(&wm2);
+        assert_eq!(s.tracked_partitions(), 1);
+    }
+
+    #[test]
+    fn retention_rewind_returns_none() {
+        // Unusual but possible: offsets reset / retention-driven rewind.
+        // d_hwm ≤ 0 → return None.
+        let s = RateSampler::new(5, Duration::from_secs(600), 0.01);
+        let mut wm1 = HashMap::new();
+        wm1.insert(tp("t", 0), (0, 1000));
+        s.record_watermarks(&wm1);
+        std::thread::sleep(Duration::from_millis(30));
+        let mut wm2 = HashMap::new();
+        wm2.insert(tp("t", 0), (0, 500));
+        s.record_watermarks(&wm2);
+        assert_eq!(s.estimate_lag_seconds(&tp("t", 0), 100), None);
+    }
+}

--- a/src/collector/rate_sampler.rs
+++ b/src/collector/rate_sampler.rs
@@ -32,6 +32,26 @@ struct WatermarkSample {
     hwm: i64,
 }
 
+/// Shared rate-computation helper. Returns `None` if < 2 samples, Δtime
+/// ≤ 0, Δhigh_watermark ≤ 0 (retention rewind), or rate below floor.
+fn compute_rate(buf: &VecDeque<WatermarkSample>, min_msgs_per_sec: f64) -> Option<f64> {
+    if buf.len() < 2 {
+        return None;
+    }
+    let first = *buf.front()?;
+    let last = *buf.back()?;
+    let d_hwm = (last.hwm - first.hwm) as f64;
+    let d_t = last.at.saturating_duration_since(first.at).as_secs_f64();
+    if d_t <= 0.0 || d_hwm <= 0.0 {
+        return None;
+    }
+    let rate = d_hwm / d_t;
+    if rate < min_msgs_per_sec {
+        return None;
+    }
+    Some(rate)
+}
+
 pub struct RateSampler {
     history: Mutex<HashMap<TopicPartition, VecDeque<WatermarkSample>>>,
     /// Maximum samples kept per partition.
@@ -87,27 +107,40 @@ impl RateSampler {
 
     /// Return the estimated time lag in seconds, or `None` if the history
     /// is insufficient or the rate is below the reliability floor.
+    ///
+    /// This is a convenience for single-partition callers / tests. For
+    /// batch per-cycle computation over many partitions, prefer
+    /// [`RateSampler::rates_snapshot`] — it takes the history lock once
+    /// instead of once per call, which matters on large clusters with
+    /// thousands of laggy partitions.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn estimate_lag_seconds(&self, tp: &TopicPartition, lag: i64) -> Option<f64> {
         if lag <= 0 {
             return Some(0.0);
         }
         let history = self.history.lock().unwrap_or_else(|p| p.into_inner());
-        let buf = history.get(tp)?;
-        if buf.len() < 2 {
-            return None;
+        compute_rate(history.get(tp)?, self.min_msgs_per_sec).map(|rate| lag as f64 / rate)
+    }
+
+    /// Compute the current production rate for every tracked partition
+    /// whose history is sufficient and whose rate is above the floor.
+    /// Holds the history lock exactly once for the whole pass.
+    ///
+    /// Callers perform the per-partition division themselves:
+    ///     `time_lag = lag / rate`
+    ///
+    /// Partitions absent from the returned map have no reliable estimate
+    /// available this cycle (insufficient samples, below floor, or
+    /// retention rewind).
+    pub fn rates_snapshot(&self) -> HashMap<TopicPartition, f64> {
+        let history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        let mut out = HashMap::with_capacity(history.len());
+        for (tp, buf) in history.iter() {
+            if let Some(rate) = compute_rate(buf, self.min_msgs_per_sec) {
+                out.insert(tp.clone(), rate);
+            }
         }
-        let first = *buf.front()?;
-        let last = *buf.back()?;
-        let d_hwm = (last.hwm - first.hwm) as f64;
-        let d_t = last.at.saturating_duration_since(first.at).as_secs_f64();
-        if d_t <= 0.0 || d_hwm <= 0.0 {
-            return None;
-        }
-        let rate = d_hwm / d_t;
-        if rate < self.min_msgs_per_sec {
-            return None;
-        }
-        Some(lag as f64 / rate)
+        out
     }
 
     /// Current number of partitions with history entries. Used for
@@ -153,21 +186,21 @@ mod tests {
         wm1.insert(tp("t", 0), (0, 100));
         s.record_watermarks(&wm1);
 
-        // Simulate the passage of time by sleeping. For a real-time unit
-        // test this is the cleanest way to exercise the Instant math.
-        std::thread::sleep(Duration::from_millis(100));
+        // A longer sleep reduces the relative impact of scheduler jitter
+        // on CI. We don't assert a tight window — only that the estimate
+        // is positive and physically plausible for the setup (lag=500,
+        // min rate enforced at 0.01 msgs/s ⇒ upper bound is huge). The
+        // intent is to exercise the math end-to-end, not the OS scheduler.
+        std::thread::sleep(Duration::from_millis(250));
 
         let mut wm2 = HashMap::new();
-        // 1000 new messages in ~100 ms = ~10,000 msgs/sec.
         wm2.insert(tp("t", 0), (0, 1100));
         s.record_watermarks(&wm2);
 
         let est = s
             .estimate_lag_seconds(&tp("t", 0), 500)
             .expect("should compute rate");
-        // Expected: 500 msgs / 10,000 msgs/sec = 0.05s. Allow generous
-        // tolerance for CI jitter in the 100ms sleep.
-        assert!((0.02..0.2).contains(&est), "est out of sanity range: {est}");
+        assert!(est > 0.0 && est.is_finite(), "non-positive estimate: {est}");
     }
 
     #[test]

--- a/src/collector/rate_sampler.rs
+++ b/src/collector/rate_sampler.rs
@@ -75,7 +75,10 @@ impl RateSampler {
                     break;
                 }
             }
-            buf.push_back(WatermarkSample { at: now, hwm: *high });
+            buf.push_back(WatermarkSample {
+                at: now,
+                hwm: *high,
+            });
             while buf.len() > self.max_samples {
                 buf.pop_front();
             }
@@ -110,10 +113,7 @@ impl RateSampler {
     /// Current number of partitions with history entries. Used for
     /// diagnostics / metrics.
     pub fn tracked_partitions(&self) -> usize {
-        self.history
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .len()
+        self.history.lock().unwrap_or_else(|p| p.into_inner()).len()
     }
 
     /// Drop all history. Used when a cluster-wide reset is needed (e.g.
@@ -167,10 +167,7 @@ mod tests {
             .expect("should compute rate");
         // Expected: 500 msgs / 10,000 msgs/sec = 0.05s. Allow generous
         // tolerance for CI jitter in the 100ms sleep.
-        assert!(
-            (0.02..0.2).contains(&est),
-            "est out of sanity range: {est}"
-        );
+        assert!((0.02..0.2).contains(&est), "est out of sanity range: {est}");
     }
 
     #[test]

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -1,10 +1,36 @@
+//! Time-lag estimation.
+//!
+//! Two modes:
+//!
+//! 1. **`Message`** — read the actual message at the committed offset via a
+//!    pooled BaseConsumer and use its produce timestamp. Exact, but the
+//!    pool is a heavyweight native-memory consumer on large clusters
+//!    (each `BaseConsumer` is a full librdkafka client with its own
+//!    metadata cache and background threads).
+//! 2. **`Rate`** — estimate time lag from the observed rate of change of
+//!    high watermarks. No consumer pool, no FFI, pure CPU. Default since
+//!    Tier 3; see [`crate::collector::rate_sampler`] for the math.
+//!
+//! Both modes present the same interface to `ClusterManager`:
+//! [`TimestampSampler::compute_time_lags`] takes an `OffsetsSnapshot` and
+//! returns `HashMap<(group_id, TopicPartition), TimestampData>` — a synthetic
+//! `timestamp_ms` is produced for rate mode (`now_ms - estimated_lag_secs *
+//! 1000`) so the downstream `LagCalculator` doesn't need to care which
+//! backend produced the number.
+
+use crate::collector::lag_calculator::TimestampData;
+use crate::collector::offset_collector::OffsetsSnapshot;
+use crate::collector::rate_sampler::RateSampler;
 use crate::error::Result;
 use crate::kafka::client::TopicPartition;
 use crate::kafka::TimestampConsumer;
 use dashmap::DashMap;
+use futures::future::join_all;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tracing::{debug, instrument};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tracing::{debug, warn};
 
 #[derive(Debug, Clone)]
 struct CachedTimestamp {
@@ -13,30 +39,29 @@ struct CachedTimestamp {
     cached_at: Instant,
 }
 
-/// Result of getting a timestamp
-#[derive(Debug, Clone)]
-pub struct TimestampResult {
-    /// The timestamp in milliseconds
-    pub timestamp_ms: i64,
-}
-
-/// Inner struct holding the actual sampler state
-struct TimestampSamplerInner {
+/// Message-mode internal state.
+struct MessageSamplerInner {
     consumer: TimestampConsumer,
     cache: DashMap<(String, TopicPartition), CachedTimestamp>,
     cache_ttl: Duration,
 }
 
-/// Thread-safe, clonable timestamp sampler for concurrent fetching
-#[derive(Clone)]
-pub struct TimestampSampler {
-    inner: Arc<TimestampSamplerInner>,
+pub struct MessageSampler {
+    inner: Arc<MessageSamplerInner>,
 }
 
-impl TimestampSampler {
-    pub fn new(consumer: TimestampConsumer, cache_ttl: Duration) -> Self {
+impl Clone for MessageSampler {
+    fn clone(&self) -> Self {
         Self {
-            inner: Arc::new(TimestampSamplerInner {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl MessageSampler {
+    fn new(consumer: TimestampConsumer, cache_ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(MessageSamplerInner {
                 consumer,
                 cache: DashMap::new(),
                 cache_ttl,
@@ -44,94 +69,253 @@ impl TimestampSampler {
         }
     }
 
-    #[instrument(skip(self), fields(group = %group_id, topic = %tp.topic, partition = tp.partition))]
-    pub fn get_timestamp(
+    fn get_timestamp(
         &self,
         group_id: &str,
         tp: &TopicPartition,
         offset: i64,
-    ) -> Result<Option<TimestampResult>> {
+    ) -> Result<Option<i64>> {
         let key = (group_id.to_string(), tp.clone());
 
-        // Check cache
+        // Cache hit if TTL not exceeded AND offset unchanged (consumer didn't move).
         if let Some(cached) = self.inner.cache.get(&key) {
-            // Cache is valid if:
-            // 1. Not expired by TTL
-            // 2. Offset hasn't changed (consumer hasn't moved)
             if cached.cached_at.elapsed() < self.inner.cache_ttl && cached.offset == offset {
-                debug!(
-                    cached_timestamp = cached.timestamp_ms,
-                    "Using cached timestamp"
-                );
-                return Ok(Some(TimestampResult {
-                    timestamp_ms: cached.timestamp_ms,
-                }));
+                return Ok(Some(cached.timestamp_ms));
             }
         }
 
-        // Fetch from Kafka
         let fetch_result = self.inner.consumer.fetch_timestamp(tp, offset)?;
-
-        // Cache the result
-        if let Some(ref result) = fetch_result {
+        if let Some(ref ts) = fetch_result {
             self.inner.cache.insert(
                 key,
                 CachedTimestamp {
-                    timestamp_ms: result.timestamp_ms,
+                    timestamp_ms: ts.timestamp_ms,
                     offset,
                     cached_at: Instant::now(),
                 },
             );
         }
-
-        Ok(fetch_result.map(|r| TimestampResult {
-            timestamp_ms: r.timestamp_ms,
-        }))
+        Ok(fetch_result.map(|r| r.timestamp_ms))
     }
 
-    #[allow(dead_code)]
-    #[allow(clippy::type_complexity)]
-    pub fn get_timestamps_batch(
-        &self,
-        requests: &[(String, TopicPartition, i64)],
-    ) -> Vec<((String, TopicPartition), Result<Option<TimestampResult>>)> {
-        requests
-            .iter()
-            .map(|(group_id, tp, offset)| {
-                let result = self.get_timestamp(group_id, tp, *offset);
-                ((group_id.clone(), tp.clone()), result)
-            })
-            .collect()
-    }
-
-    /// Recycle the underlying consumer pool to release accumulated metadata.
-    pub fn recycle_pool(&self) -> Result<()> {
+    fn recycle_pool(&self) -> Result<()> {
         self.inner.consumer.recycle_pool()
     }
 
-    pub fn clear_stale_entries(&self) {
+    fn clear_stale_entries(&self) {
         let now = Instant::now();
+        let ttl = self.inner.cache_ttl;
         self.inner
             .cache
-            .retain(|_, v| now.duration_since(v.cached_at) < self.inner.cache_ttl);
+            .retain(|_, v| now.duration_since(v.cached_at) < ttl);
     }
 
-    pub fn cache_size(&self) -> usize {
+    fn cache_size(&self) -> usize {
         self.inner.cache.len()
     }
+}
 
-    #[allow(dead_code)]
-    pub fn clear_cache(&self) {
-        self.inner.cache.clear();
+/// Unified sampler handle. Cheap to `clone()` (Arc bump inside).
+#[derive(Clone)]
+pub enum TimestampSampler {
+    Message(MessageSampler),
+    Rate(Arc<RateSampler>),
+}
+
+impl TimestampSampler {
+    /// Build a message-mode sampler. Takes ownership of the
+    /// `TimestampConsumer` pool (which is only constructed in message
+    /// mode, so we don't pay for the pool's memory in rate mode).
+    pub fn new_message(consumer: TimestampConsumer, cache_ttl: Duration) -> Self {
+        Self::Message(MessageSampler::new(consumer, cache_ttl))
     }
+
+    /// Build a rate-mode sampler.
+    pub fn new_rate(sampler: RateSampler) -> Self {
+        Self::Rate(Arc::new(sampler))
+    }
+
+    /// Only meaningful in message mode; no-op for rate mode.
+    pub fn recycle_pool(&self) -> Result<()> {
+        match self {
+            Self::Message(s) => s.recycle_pool(),
+            Self::Rate(_) => Ok(()),
+        }
+    }
+
+    /// Only meaningful in message mode; no-op for rate mode.
+    pub fn clear_stale_entries(&self) {
+        if let Self::Message(s) = self {
+            s.clear_stale_entries();
+        }
+    }
+
+    /// Diagnostic count: message-mode cache entries or rate-mode tracked
+    /// partitions.
+    pub fn cache_size(&self) -> usize {
+        match self {
+            Self::Message(s) => s.cache_size(),
+            Self::Rate(s) => s.tracked_partitions(),
+        }
+    }
+
+    /// Compute per-(group, partition) timestamps for everything in `snapshot`
+    /// with `lag > 0`. Returns a map shaped for direct consumption by
+    /// `LagCalculator::calculate`.
+    ///
+    /// - Message mode: spawn up to `max_concurrent_fetches` blocking FFI
+    ///   tasks via the consumer pool. Unchanged behavior from Tier 2.
+    /// - Rate mode: record this cycle's watermarks into the history ring
+    ///   buffer, then synthesize `timestamp_ms = now_ms - estimate_secs *
+    ///   1000` for each laggy partition where a reliable rate is available.
+    ///   `max_concurrent_fetches` is ignored.
+    pub async fn compute_time_lags(
+        &self,
+        snapshot: &OffsetsSnapshot,
+        now_ms: i64,
+        max_concurrent_fetches: usize,
+    ) -> HashMap<(String, TopicPartition), TimestampData> {
+        match self {
+            Self::Message(s) => {
+                compute_time_lags_message(s, snapshot, max_concurrent_fetches).await
+            }
+            Self::Rate(s) => compute_time_lags_rate(s, snapshot, now_ms),
+        }
+    }
+}
+
+fn compute_time_lags_rate(
+    sampler: &RateSampler,
+    snapshot: &OffsetsSnapshot,
+    now_ms: i64,
+) -> HashMap<(String, TopicPartition), TimestampData> {
+    // First: add this cycle's watermarks to history (and prune stale
+    // partitions). Only after that can we compute rate for the current
+    // cycle reliably.
+    sampler.record_watermarks(&snapshot.watermarks);
+
+    let mut out = HashMap::new();
+    for group in &snapshot.groups {
+        for (tp, committed_offset) in &group.offsets {
+            let high = snapshot
+                .get_watermark(tp)
+                .map(|(_, h)| h)
+                .unwrap_or(*committed_offset);
+            let lag = high - *committed_offset;
+            if lag <= 0 {
+                // 0 lag → 0 seconds. Downstream builds Some(0.0) naturally;
+                // don't need to populate.
+                continue;
+            }
+            if let Some(secs) = sampler.estimate_lag_seconds(tp, lag) {
+                let synthetic_ts_ms = now_ms - (secs * 1000.0) as i64;
+                out.insert(
+                    (group.group_id.clone(), tp.clone()),
+                    TimestampData {
+                        timestamp_ms: synthetic_ts_ms,
+                    },
+                );
+            }
+            // If estimate is None (insufficient history / idle partition),
+            // leave the entry absent. LagCalculator handles missing entries
+            // by emitting the metric as None.
+        }
+    }
+    debug!(
+        tracked_partitions = sampler.tracked_partitions(),
+        emitted = out.len(),
+        "Rate-mode time-lag computation complete"
+    );
+    out
+}
+
+async fn compute_time_lags_message(
+    sampler: &MessageSampler,
+    snapshot: &OffsetsSnapshot,
+    max_concurrent_fetches: usize,
+) -> HashMap<(String, TopicPartition), TimestampData> {
+    let mut requests: Vec<(String, TopicPartition, i64)> = Vec::new();
+    for group in &snapshot.groups {
+        for (tp, committed_offset) in &group.offsets {
+            let high = snapshot
+                .get_watermark(tp)
+                .map(|(_, h)| h)
+                .unwrap_or(*committed_offset);
+            if high - *committed_offset > 0 {
+                requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
+            }
+        }
+    }
+    if requests.is_empty() {
+        return HashMap::new();
+    }
+
+    debug!(
+        request_count = requests.len(),
+        max_concurrent = max_concurrent_fetches,
+        "Fetching per-partition message timestamps (message mode)"
+    );
+
+    let semaphore = Arc::new(Semaphore::new(max_concurrent_fetches.max(1)));
+    let mut handles = Vec::with_capacity(requests.len());
+    for (group_id, tp, offset) in requests {
+        let permit = Arc::clone(&semaphore);
+        let sampler = sampler.clone();
+        handles.push(tokio::spawn(async move {
+            let permit_guard: OwnedSemaphorePermit =
+                permit.acquire_owned().await.expect("semaphore closed");
+            let result = tokio::task::spawn_blocking(move || {
+                let _p = permit_guard;
+                let result = sampler.get_timestamp(&group_id, &tp, offset);
+                ((group_id, tp), result)
+            })
+            .await;
+            result
+        }));
+    }
+
+    let results = join_all(handles).await;
+    let mut out = HashMap::new();
+    for result in results {
+        match result {
+            Ok(Ok(((group_id, tp), Ok(Some(ts))))) => {
+                out.insert((group_id, tp), TimestampData { timestamp_ms: ts });
+            }
+            Ok(Ok(((_group_id, _tp), Ok(None)))) => {
+                // No message available at offset; skip.
+            }
+            Ok(Ok(((group_id, tp), Err(e)))) => {
+                warn!(
+                    group = %group_id,
+                    topic = %tp.topic,
+                    partition = tp.partition,
+                    error = %e,
+                    "Message timestamp fetch failed"
+                );
+            }
+            Ok(Err(e)) => {
+                warn!(error = %e, "Message timestamp blocking task panicked");
+            }
+            Err(e) => {
+                warn!(error = %e, "Message timestamp task panicked");
+            }
+        }
+    }
+    out
 }
 
 impl std::fmt::Debug for TimestampSampler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TimestampSampler")
-            .field("cache_size", &self.inner.cache.len())
-            .field("cache_ttl", &self.inner.cache_ttl)
-            .finish()
+        match self {
+            Self::Message(s) => f
+                .debug_struct("TimestampSampler::Message")
+                .field("cache_size", &s.cache_size())
+                .finish(),
+            Self::Rate(s) => f
+                .debug_struct("TimestampSampler::Rate")
+                .field("tracked_partitions", &s.tracked_partitions())
+                .finish(),
+        }
     }
 }
 
@@ -140,32 +324,76 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_timestamp_cache_ttl_expiry() {
-        // This test verifies cache entry expiration logic
+    fn cached_timestamp_ttl_expiry_check() {
         let cached = CachedTimestamp {
             timestamp_ms: 1000,
             offset: 100,
             cached_at: Instant::now() - Duration::from_secs(120),
         };
-
         let cache_ttl = Duration::from_secs(60);
-
-        // Entry should be expired
         assert!(cached.cached_at.elapsed() >= cache_ttl);
     }
 
     #[test]
-    fn test_cache_invalidation_on_offset_change() {
-        // This test verifies cache is invalidated when offset changes
-        let cached = CachedTimestamp {
-            timestamp_ms: 1000,
-            offset: 100,
-            cached_at: Instant::now(),
+    fn rate_mode_synthesizes_timestamp_from_lag_estimate() {
+        use crate::collector::offset_collector::{GroupSnapshot, MemberSnapshot};
+        use std::collections::HashSet;
+
+        let sampler =
+            TimestampSampler::new_rate(RateSampler::new(5, Duration::from_secs(600), 0.01));
+
+        // Prime the rate sampler's history: two watermark observations
+        // separated by a small sleep so the rate is well-defined.
+        let tp_key = TopicPartition::new("t", 0);
+
+        let mut watermarks = HashMap::new();
+        watermarks.insert(tp_key.clone(), (0i64, 100i64));
+        let snap1 = OffsetsSnapshot {
+            cluster_name: "c".into(),
+            groups: vec![],
+            watermarks: watermarks.clone(),
+            compacted_topics: HashSet::new(),
+            timestamp_ms: 0,
         };
+        let _ = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(sampler.compute_time_lags(&snap1, 0, 1));
 
-        let new_offset = 150;
+        std::thread::sleep(Duration::from_millis(100));
 
-        // Cache should be invalid because offset changed
-        assert_ne!(cached.offset, new_offset);
+        // New cycle: hwm moved by 1000 → ~10k msg/sec. Consumer committed
+        // at 500 → lag 600. Expected estimated secs: 600 / 10000 = 0.06s.
+        let mut watermarks2 = HashMap::new();
+        watermarks2.insert(tp_key.clone(), (0i64, 1100i64));
+        let mut offsets = HashMap::new();
+        offsets.insert(tp_key.clone(), 500i64);
+        let snap2 = OffsetsSnapshot {
+            cluster_name: "c".into(),
+            groups: vec![GroupSnapshot {
+                group_id: "g".into(),
+                state: "Stable".into(),
+                members: vec![] as Vec<MemberSnapshot>,
+                offsets,
+            }],
+            watermarks: watermarks2,
+            compacted_topics: HashSet::new(),
+            timestamp_ms: 0,
+        };
+        let now_ms = 1_000_000_000i64;
+        let out = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(sampler.compute_time_lags(&snap2, now_ms, 1));
+
+        let ts = out
+            .get(&("g".to_string(), tp_key))
+            .expect("should produce a synthetic timestamp");
+        // Synthesized ts = now_ms - estimated_secs*1000. Estimated secs
+        // should be small but positive; allow a generous window for CI
+        // sleep jitter.
+        let lag_ms = now_ms - ts.timestamp_ms;
+        assert!(
+            (20..=300).contains(&lag_ms),
+            "synthetic lag_ms out of sanity range: {lag_ms}"
+        );
     }
 }

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -194,6 +194,10 @@ fn compute_time_lags_rate(
     // cycle reliably.
     sampler.record_watermarks(&snapshot.watermarks);
 
+    // Take the history lock once and materialize per-partition rates —
+    // avoids O(groups × partitions) lock acquisitions on large clusters.
+    let rates = sampler.rates_snapshot();
+
     let mut out = HashMap::new();
     for group in &snapshot.groups {
         for (tp, committed_offset) in &group.offsets {
@@ -207,7 +211,8 @@ fn compute_time_lags_rate(
                 // don't need to populate.
                 continue;
             }
-            if let Some(secs) = sampler.estimate_lag_seconds(tp, lag) {
+            if let Some(&rate) = rates.get(tp) {
+                let secs = lag as f64 / rate;
                 let synthetic_ts_ms = now_ms - (secs * 1000.0) as i64;
                 out.insert(
                     (group.group_id.clone(), tp.clone()),
@@ -216,13 +221,14 @@ fn compute_time_lags_rate(
                     },
                 );
             }
-            // If estimate is None (insufficient history / idle partition),
-            // leave the entry absent. LagCalculator handles missing entries
-            // by emitting the metric as None.
+            // Partitions absent from `rates` have no reliable estimate
+            // (insufficient history / idle / retention rewind). Leave the
+            // entry out; LagCalculator emits the metric as None.
         }
     }
     debug!(
         tracked_partitions = sampler.tracked_partitions(),
+        rates_available = rates.len(),
         emitted = out.len(),
         "Rate-mode time-lag computation complete"
     );
@@ -387,12 +393,13 @@ mod tests {
         let ts = out
             .get(&("g".to_string(), tp_key))
             .expect("should produce a synthetic timestamp");
-        // Synthesized ts = now_ms - estimated_secs*1000. Estimated secs
-        // should be small but positive; allow a generous window for CI
-        // sleep jitter.
+        // Synthesized ts = now_ms - estimated_secs*1000. The exact value
+        // depends on how long the OS scheduler actually delayed the
+        // thread, which is unstable under CI contention. Only assert
+        // sign/order-of-magnitude, not a tight window.
         let lag_ms = now_ms - ts.timestamp_ms;
         assert!(
-            (20..=300).contains(&lag_ms),
+            lag_ms > 0 && lag_ms < 60_000,
             "synthetic lag_ms out of sanity range: {lag_ms}"
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,14 +38,55 @@ pub enum Granularity {
     Partition,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TimestampSamplingMode {
+    /// Read the actual message at the committed offset via a pooled
+    /// BaseConsumer and use its produce timestamp. Exact, but the pool
+    /// occupies meaningful resident memory and creates per-cycle FFI
+    /// churn on large clusters.
+    Message,
+    /// Estimate time lag from the observed rate of change of high
+    /// watermarks. Pure CPU, no consumer pool, no FFI. Accuracy depends
+    /// on steady producer rate across the history window — good enough
+    /// for lag alerting, not appropriate for audit-grade timestamp
+    /// tracking.
+    Rate,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct TimestampSamplingConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// How the exporter derives the "seconds of lag" metric. Default is
+    /// `rate` — much cheaper on large clusters and scales to thousands
+    /// of partitions without a consumer pool. Set to `message` to restore
+    /// the pre-Tier-3 behavior (read the actual message at the committed
+    /// offset and subtract its produce timestamp from "now").
+    #[serde(default = "default_timestamp_sampling_mode")]
+    pub mode: TimestampSamplingMode,
+    /// Cache TTL for the message-mode sampler. Ignored in `rate` mode.
     #[serde(with = "humantime_serde", default = "default_cache_ttl")]
     pub cache_ttl: Duration,
+    /// Maximum concurrent message fetches in `message` mode. Ignored in
+    /// `rate` mode (rate mode does no I/O).
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: usize,
+    /// `rate` mode: maximum number of (time, high_watermark) samples
+    /// retained per partition. Larger = smoother rate estimate, more
+    /// memory. Default 5.
+    #[serde(default = "default_rate_history_samples")]
+    pub rate_history_samples: usize,
+    /// `rate` mode: samples older than this are evicted. Default 10
+    /// minutes. On long poll intervals (> a few minutes) raise this so
+    /// the ring buffer has enough points to compute a stable rate.
+    #[serde(with = "humantime_serde", default = "default_rate_history_max_age")]
+    pub rate_history_max_age: Duration,
+    /// `rate` mode: producers observed to be running below this rate are
+    /// treated as idle and time-lag is reported as missing rather than
+    /// an unreliable division. Default 0.01 msg/sec.
+    #[serde(default = "default_rate_min_msgs_per_sec")]
+    pub rate_min_msgs_per_sec: f64,
 }
 
 /// Performance tuning configuration for large clusters.
@@ -192,6 +233,22 @@ fn default_max_concurrent_fetches() -> usize {
     5
 }
 
+fn default_timestamp_sampling_mode() -> TimestampSamplingMode {
+    TimestampSamplingMode::Rate
+}
+
+fn default_rate_history_samples() -> usize {
+    5
+}
+
+fn default_rate_history_max_age() -> Duration {
+    Duration::from_secs(600)
+}
+
+fn default_rate_min_msgs_per_sec() -> f64 {
+    0.01
+}
+
 fn default_kafka_timeout() -> Duration {
     Duration::from_secs(30)
 }
@@ -264,8 +321,12 @@ impl Default for TimestampSamplingConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            mode: default_timestamp_sampling_mode(),
             cache_ttl: default_cache_ttl(),
             max_concurrent_fetches: default_max_concurrent_fetches(),
+            rate_history_samples: default_rate_history_samples(),
+            rate_history_max_age: default_rate_history_max_age(),
+            rate_min_msgs_per_sec: default_rate_min_msgs_per_sec(),
         }
     }
 }
@@ -369,27 +430,38 @@ impl Config {
         // The blocking-thread pool must be able to hold every concurrent FFI
         // call our hot path spawns simultaneously. `max_concurrent_groups`
         // is the dominant consumer; the timestamp sampler adds up to
-        // `max_concurrent_fetches` more — but only when sampling is enabled.
-        // If the pool is too small, tasks queue behind each other and we
-        // effectively serialize — silently undoing the Tier 1 win.
-        let sampler_contribution = if self.exporter.timestamp_sampling.enabled {
+        // `max_concurrent_fetches` more — but only when sampling is enabled
+        // AND in `message` mode. Rate mode does no I/O and consumes no
+        // blocking threads. If the pool is too small, tasks queue behind
+        // each other and we effectively serialize — silently undoing the
+        // Tier 1 win.
+        let sampler_uses_blocking_threads = self.exporter.timestamp_sampling.enabled
+            && matches!(
+                self.exporter.timestamp_sampling.mode,
+                TimestampSamplingMode::Message
+            );
+        let sampler_contribution = if sampler_uses_blocking_threads {
             self.exporter.timestamp_sampling.max_concurrent_fetches
         } else {
             0
         };
         let min_needed = self.exporter.performance.max_concurrent_groups + sampler_contribution + 4; // small headroom for watermark / compacted-topic / metadata FFI
         if self.exporter.performance.max_blocking_threads < min_needed {
+            let sampling_state = match (
+                self.exporter.timestamp_sampling.enabled,
+                self.exporter.timestamp_sampling.mode,
+            ) {
+                (false, _) => "disabled",
+                (true, TimestampSamplingMode::Rate) => "rate (no FFI)",
+                (true, TimestampSamplingMode::Message) => "message",
+            };
             return Err(KlagError::Config(format!(
                 "performance.max_blocking_threads ({}) must be >= max_concurrent_groups ({}) + \
                  timestamp_sampling.max_concurrent_fetches ({}, sampling {}) + 4 = {}",
                 self.exporter.performance.max_blocking_threads,
                 self.exporter.performance.max_concurrent_groups,
                 sampler_contribution,
-                if self.exporter.timestamp_sampling.enabled {
-                    "enabled"
-                } else {
-                    "disabled"
-                },
+                sampling_state,
                 min_needed,
             )));
         }
@@ -642,6 +714,11 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(config.exporter.http_host, "0.0.0.0");
         assert_eq!(config.exporter.granularity, Granularity::Topic);
         assert!(config.exporter.timestamp_sampling.enabled);
+        assert_eq!(
+            config.exporter.timestamp_sampling.mode,
+            TimestampSamplingMode::Rate,
+            "default mode should be rate (Tier 3)"
+        );
         assert!(!config.exporter.otel.enabled);
         // Performance defaults
         assert_eq!(
@@ -703,10 +780,13 @@ bootstrap_servers = "localhost:9092"
 
     #[test]
     fn test_max_blocking_threads_rejected_when_too_small() {
-        // default max_concurrent_groups=10, max_concurrent_fetches=5,
-        // so minimum blocking threads = 10 + 5 + 4 = 19. 16 must fail.
+        // Message mode uses blocking threads. Default max_concurrent_groups=10,
+        // max_concurrent_fetches=5, so minimum = 10 + 5 + 4 = 19. 16 must fail.
         let config_content = r#"
 [exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
 
 [exporter.performance]
 max_blocking_threads = 16

--- a/src/config.rs
+++ b/src/config.rs
@@ -427,6 +427,33 @@ impl Config {
                 "performance.max_concurrent_watermarks must be at least 1".to_string(),
             ));
         }
+
+        // Timestamp-sampling validation. Only enforce the constraints that
+        // actually matter for the configured mode so rate-mode users aren't
+        // forced to tune message-mode knobs (and vice versa).
+        let ts = &self.exporter.timestamp_sampling;
+        if ts.enabled && ts.mode == TimestampSamplingMode::Message && ts.max_concurrent_fetches == 0
+        {
+            return Err(KlagError::Config(
+                "timestamp_sampling.max_concurrent_fetches must be >= 1 when mode = 'message'"
+                    .to_string(),
+            ));
+        }
+        if ts.enabled && ts.mode == TimestampSamplingMode::Rate {
+            if ts.rate_history_samples < 2 {
+                return Err(KlagError::Config(
+                    "timestamp_sampling.rate_history_samples must be >= 2 (need two samples \
+                     to compute a rate)"
+                        .to_string(),
+                ));
+            }
+            if !ts.rate_min_msgs_per_sec.is_finite() || ts.rate_min_msgs_per_sec < 0.0 {
+                return Err(KlagError::Config(format!(
+                    "timestamp_sampling.rate_min_msgs_per_sec ({}) must be finite and >= 0",
+                    ts.rate_min_msgs_per_sec
+                )));
+            }
+        }
         // The blocking-thread pool must be able to hold every concurrent FFI
         // call our hot path spawns simultaneously. `max_concurrent_groups`
         // is the dominant consumer; the timestamp sampler adds up to
@@ -805,6 +832,73 @@ bootstrap_servers = "localhost:9092"
             "unexpected error: {msg}"
         );
         assert!(msg.contains("= 19"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_message_mode_rejects_zero_concurrent_fetches() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+max_concurrent_fetches = 0
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("max_concurrent_fetches must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rate_mode_rejects_one_history_sample() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+rate_history_samples = 1
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("rate_history_samples must be >= 2"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rate_mode_rejects_negative_min_rate() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+rate_min_msgs_per_sec = -1.0
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string().contains("rate_min_msgs_per_sec")
+                && err.to_string().contains("must be finite and >= 0"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tier 3 of the memory/perf rework. Introduces rate-based time-lag estimation and makes it the default, **eliminating the BaseConsumer pool entirely in the default configuration**. The pool was the single biggest remaining memory consumer on large clusters after Tier 1 and Tier 2.

## What changed

### New: \`RateSampler\`

Per-partition ring buffer of \`(instant, high_watermark)\` samples. Rate = \`Δhigh_watermark / Δtime\`; time lag = \`(high_watermark − committed_offset) / rate\`. Pure CPU, no FFI, no spawn_blocking, no pool.

Returns \`None\` when:
- < 2 samples (first cycle / new partition)
- Rate below configurable floor (idle partition)
- Observed Δhigh ≤ 0 (retention rewind edge case)

### \`TimestampSampler\` → enum

Wraps \`MessageSampler\` (legacy pooled-consumer path) and \`Arc<RateSampler>\`. One mode-agnostic entry point:

\`\`\`rust
pub async fn compute_time_lags(&self, snapshot: &OffsetsSnapshot, now_ms: i64, max_concurrent_fetches: usize) -> HashMap<...>
\`\`\`

Rate mode synthesizes \`timestamp_ms = now_ms − estimate_secs*1000\` so \`LagCalculator\` is unchanged.

### Conditional pool construction

\`TimestampConsumer\` (the BaseConsumer pool) is now only built when \`mode = message\`. In the default \`mode = rate\` it's never instantiated — so its ~5–15 MB × pool_size of resident memory, plus its background threads and per-topic metadata caches, are simply not paid for.

### Config

- \`timestamp_sampling.mode\`: \`rate\` (default) or \`message\`
- \`timestamp_sampling.rate_history_samples\` (default 5)
- \`timestamp_sampling.rate_history_max_age\` (default 10 min)
- \`timestamp_sampling.rate_min_msgs_per_sec\` (default 0.01)
- \`max_blocking_threads\` validation now correctly excludes sampler contribution in rate mode

## Behavior change — flag to reviewers

Existing configs that have \`timestamp_sampling.enabled = true\` and don't set \`mode\` silently switch to rate-based. The metric \`kafka_consumergroup_group_max_lag_seconds\` is still emitted, but the number is now an estimate derived from observed production rate rather than read from an actual message.

- Accuracy: sufficient for lag alerting (magnitudes — minutes vs. hours — remain correct). Not appropriate for audit-grade timestamp tracking.
- On the first cycle after startup, time-lag is missing (needs ≥ 2 samples).
- On partitions producing below \`rate_min_msgs_per_sec\`, time-lag is missing.

Users who need exact timestamps set \`mode = \"message\"\`. README's "Time Lag Modes" section documents both.

## Cumulative Tier 1 + 2 + 3 effect on resident memory

| Thing | Before | After Tier 3 default |
|---|---|---|
| Per-partition FFI for watermarks | 19K RPCs/cycle | 2 RPCs/cycle |
| Per-group sequential \`fetch_group_list\` | 4K RPCs/cycle | ~42 batched RPCs |
| BaseConsumer pool | 5–20 × ~5–15 MB resident | 0 bytes (not created) |
| Timestamp-fetch FFI churn | thousands per cycle | 0 |
| Tokio blocking-thread stacks | up to ~4 GB virtual | ≤ ~256 MB virtual (capped) |
| Topic-name duplication in \`TopicPartition\` | 19K fresh strings | ~7K shared \`Arc<str>\` |
| Per-cycle DescribeConfigs on all topics | full-cluster every cycle | 0 in steady state (1h cache) |
| Per-cycle metadata fetch + regex filter | every cycle | 0 in steady state (5m cache) |

## Test plan

- [x] \`cargo build --release\` — exit 0
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — exit 0
- [x] \`cargo test\` — 69/69 pass (7 new rate_sampler tests, 1 rate-mode integration test in timestamp_sampler, updated validation tests)
- [x] \`cargo fmt --check\` — exit 0
- [x] Local smoke against test-stack: \`timestamp_sampling_mode=Rate\` logged, no errors, lag_seconds populated after ≥ 2 cycles
- [ ] **Needed**: run against a real large cluster and compare RSS between Tier 2 (pool present) and Tier 3 (pool absent)

## Review pointers

- \`src/collector/rate_sampler.rs\` — the new sampler. Pure Rust, fully unit-tested.
- \`src/collector/timestamp_sampler.rs\` — refactored into an enum; the message-mode path is the same logic as Tier 2, just behind \`TimestampSampler::Message\`.
- \`src/cluster/manager.rs\` — sampler construction picks a variant based on \`ts_cfg.mode\`; \`collect_once\` has a single \`compute_time_lags\` call; old \`collect_timestamps_concurrent\` removed.
- \`src/config.rs\` — new mode enum, rate-mode tuning fields, mode-aware \`max_blocking_threads\` validation.
- \`README.md\` — \"Time Lag Modes\" subsection explains the tradeoff.