### PR TITLE
perf: parallelize describe, cache list_consumer_groups, per-phase timings (Tier 4)

### DIFF
--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -169,6 +169,19 @@ pub struct OffsetCollector {
     consumer_groups_cache: ConsumerGroupsCache,
 }
 
+/// Per-phase wall-clock timings collected during one `collect_parallel`
+/// run. Emitted as a single structured debug log at the end of the cycle
+/// so operators can see where time goes without enabling trace logging.
+#[derive(Default)]
+struct PhaseTimings {
+    list_groups_ms: u64,
+    describe_groups_ms: u64,
+    metadata_ms: u64,
+    watermarks_ms: u64,
+    group_offsets_ms: u64,
+    compacted_ms: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct OffsetsSnapshot {
     pub cluster_name: String,
@@ -238,9 +251,16 @@ impl OffsetCollector {
     pub async fn collect_parallel(&self) -> Result<OffsetsSnapshot> {
         let start = std::time::Instant::now();
 
+        // Per-phase timings, emitted as a single structured log line at
+        // the end of the cycle. Lets operators see where wall-clock time
+        // goes (list_groups vs describe vs watermarks vs offsets vs
+        // compacted-configs) without turning on trace-level logging.
+        let mut timings = PhaseTimings::default();
+
         // List all consumer groups (single metadata call).
         // TTL-cached: steady-state (stable group roster) cycles skip this
         // RPC entirely. New groups appear within one TTL of creation.
+        let phase_start = std::time::Instant::now();
         let all_groups = if let Some(cached) = self.consumer_groups_cache.get() {
             debug!(total_groups = cached.len(), "Consumer groups cache hit");
             cached
@@ -252,6 +272,7 @@ impl OffsetCollector {
             );
             self.consumer_groups_cache.set(fresh)
         };
+        timings.list_groups_ms = phase_start.elapsed().as_millis() as u64;
 
         let filtered_groups: Vec<_> = all_groups
             .iter()
@@ -271,6 +292,7 @@ impl OffsetCollector {
         // parsing unless we actually emit per-partition member labels
         // (granularity = partition).
         let parse_assignments = matches!(self.granularity, Granularity::Partition);
+        let phase_start = std::time::Instant::now();
         let descriptions = self
             .client
             .describe_consumer_groups(
@@ -279,13 +301,16 @@ impl OffsetCollector {
                 self.performance.max_concurrent_groups,
             )
             .await?;
+        timings.describe_groups_ms = phase_start.elapsed().as_millis() as u64;
 
         // Compute the monitored partition + topic set once from a single
         // metadata fetch. Topic filter is applied here, BEFORE any
         // partition-touching operation — this keeps `__consumer_offsets`
         // (50 partitions by default) and blacklisted topics out of the hot
         // path entirely.
+        let phase_start = std::time::Instant::now();
         let (monitored_partitions, monitored_topics) = self.list_monitored_partitions()?;
+        timings.metadata_ms = phase_start.elapsed().as_millis() as u64;
         debug!(
             partitions = monitored_partitions.len(),
             topics = monitored_topics.len(),
@@ -296,6 +321,7 @@ impl OffsetCollector {
         // `monitored_partitions` into the blocking closure — no subsequent
         // use in this function, and cloning an O(partitions) Vec every cycle
         // is wasted work on large clusters.
+        let phase_start = std::time::Instant::now();
         let watermarks = {
             let client = Arc::clone(&self.client);
             tokio::task::spawn_blocking(move || {
@@ -306,6 +332,7 @@ impl OffsetCollector {
                 crate::error::KlagError::Admin(format!("watermark task panicked: {e}"))
             })??
         };
+        timings.watermarks_ms = phase_start.elapsed().as_millis() as u64;
         debug!(
             partitions = watermarks.len(),
             "Fetched watermarks (batched)"
@@ -314,11 +341,14 @@ impl OffsetCollector {
         // Group offsets via batched multi-group ListConsumerGroupOffsets.
         // `NULL` partitions → broker returns every committed partition per
         // group; we then filter the (much smaller) response by topic.
+        let phase_start = std::time::Instant::now();
         let group_offsets = self.fetch_all_group_offsets_batched(&group_ids).await;
+        timings.group_offsets_ms = phase_start.elapsed().as_millis() as u64;
 
         // Compacted-topic lookup — TTL-cached per topic. `cleanup.policy`
         // almost never changes after topic creation, so most cycles only
         // refresh new topics (or nothing at all in steady state).
+        let phase_start = std::time::Instant::now();
         let (mut compacted_topics, to_fetch) = self.compacted_cache.partition(&monitored_topics);
         if !to_fetch.is_empty() {
             debug!(
@@ -347,6 +377,7 @@ impl OffsetCollector {
         // Drop cache entries for topics no longer monitored (filter change,
         // topic deletion) so memory doesn't grow unboundedly.
         self.compacted_cache.prune_to(&monitored_topics);
+        timings.compacted_ms = phase_start.elapsed().as_millis() as u64;
 
         // Build group snapshots
         let mut groups = Vec::with_capacity(descriptions.len());
@@ -383,6 +414,12 @@ impl OffsetCollector {
         let elapsed = start.elapsed();
         debug!(
             elapsed_ms = elapsed.as_millis(),
+            list_groups_ms = timings.list_groups_ms,
+            describe_groups_ms = timings.describe_groups_ms,
+            metadata_ms = timings.metadata_ms,
+            watermarks_ms = timings.watermarks_ms,
+            group_offsets_ms = timings.group_offsets_ms,
+            compacted_ms = timings.compacted_ms,
             monitored_topics = monitored_topics.len(),
             compacted_topics = compacted_topics.len(),
             "Batched collection completed"

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -221,7 +221,12 @@ impl OffsetCollector {
         let parse_assignments = matches!(self.granularity, Granularity::Partition);
         let descriptions = self
             .client
-            .describe_consumer_groups(&group_ids, parse_assignments)?;
+            .describe_consumer_groups(
+                &group_ids,
+                parse_assignments,
+                self.performance.max_concurrent_groups,
+            )
+            .await?;
 
         // Compute the monitored partition + topic set once from a single
         // metadata fetch. Topic filter is applied here, BEFORE any

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -1,6 +1,6 @@
 use crate::config::{CompiledFilters, Granularity, PerformanceConfig};
 use crate::error::Result;
-use crate::kafka::client::{KafkaClient, TopicPartition};
+use crate::kafka::client::{ConsumerGroupInfo, KafkaClient, TopicPartition};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -118,6 +118,47 @@ impl MetadataCache {
     }
 }
 
+/// TTL cache for the output of `list_consumer_groups`. The cluster's
+/// consumer-group roster is stable outside of deployments / scaling events,
+/// so re-fetching it every poll cycle is wasted work. Same shape as
+/// `MetadataCache`: one entry for the whole list, Arc-wrapped so cache
+/// hits don't deep-clone the Vec.
+struct ConsumerGroupsCache {
+    ttl: Duration,
+    entry: Mutex<Option<(Arc<Vec<ConsumerGroupInfo>>, Instant)>>,
+}
+
+impl ConsumerGroupsCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entry: Mutex::new(None),
+        }
+    }
+
+    fn get(&self) -> Option<Arc<Vec<ConsumerGroupInfo>>> {
+        if self.ttl.is_zero() {
+            return None;
+        }
+        let guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+        let (groups, at) = guard.as_ref()?;
+        if at.elapsed() < self.ttl {
+            Some(Arc::clone(groups))
+        } else {
+            None
+        }
+    }
+
+    fn set(&self, groups: Vec<ConsumerGroupInfo>) -> Arc<Vec<ConsumerGroupInfo>> {
+        let arc = Arc::new(groups);
+        if !self.ttl.is_zero() {
+            let mut guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+            *guard = Some((Arc::clone(&arc), Instant::now()));
+        }
+        arc
+    }
+}
+
 pub struct OffsetCollector {
     client: Arc<KafkaClient>,
     filters: CompiledFilters,
@@ -125,6 +166,7 @@ pub struct OffsetCollector {
     granularity: Granularity,
     compacted_cache: CompactedTopicsCache,
     metadata_cache: MetadataCache,
+    consumer_groups_cache: ConsumerGroupsCache,
 }
 
 #[derive(Debug, Clone)]
@@ -166,6 +208,7 @@ impl OffsetCollector {
     ) -> Self {
         let compacted_cache = CompactedTopicsCache::new(performance.compacted_topics_cache_ttl);
         let metadata_cache = MetadataCache::new(performance.metadata_cache_ttl);
+        let consumer_groups_cache = ConsumerGroupsCache::new(performance.consumer_groups_cache_ttl);
         Self {
             client,
             filters,
@@ -173,6 +216,7 @@ impl OffsetCollector {
             granularity,
             compacted_cache,
             metadata_cache,
+            consumer_groups_cache,
         }
     }
 
@@ -195,11 +239,19 @@ impl OffsetCollector {
         let start = std::time::Instant::now();
 
         // List all consumer groups (single metadata call).
-        let all_groups = self.client.list_consumer_groups()?;
-        debug!(
-            total_groups = all_groups.len(),
-            "Listed all consumer groups"
-        );
+        // TTL-cached: steady-state (stable group roster) cycles skip this
+        // RPC entirely. New groups appear within one TTL of creation.
+        let all_groups = if let Some(cached) = self.consumer_groups_cache.get() {
+            debug!(total_groups = cached.len(), "Consumer groups cache hit");
+            cached
+        } else {
+            let fresh = self.client.list_consumer_groups()?;
+            debug!(
+                total_groups = fresh.len(),
+                "Listed all consumer groups (fresh)"
+            );
+            self.consumer_groups_cache.set(fresh)
+        };
 
         let filtered_groups: Vec<_> = all_groups
             .iter()
@@ -607,6 +659,40 @@ mod tests {
         assert!(cache.get().is_some());
         std::thread::sleep(Duration::from_millis(70));
         assert!(cache.get().is_none(), "expired entry must miss");
+    }
+
+    #[test]
+    fn consumer_groups_cache_hit_returns_cached() {
+        let cache = ConsumerGroupsCache::new(Duration::from_secs(60));
+        assert!(cache.get().is_none(), "empty cache should miss");
+        let arc = cache.set(vec![ConsumerGroupInfo {
+            group_id: "g".into(),
+            protocol_type: String::new(),
+            state: String::new(),
+        }]);
+        assert_eq!(arc.len(), 1);
+        let cached = cache.get().expect("should hit after set");
+        assert_eq!(cached.len(), 1);
+    }
+
+    #[test]
+    fn consumer_groups_cache_zero_ttl_disabled() {
+        let cache = ConsumerGroupsCache::new(Duration::ZERO);
+        let _arc = cache.set(vec![ConsumerGroupInfo {
+            group_id: "g".into(),
+            protocol_type: String::new(),
+            state: String::new(),
+        }]);
+        assert!(cache.get().is_none());
+    }
+
+    #[test]
+    fn consumer_groups_cache_expires() {
+        let cache = ConsumerGroupsCache::new(Duration::from_millis(50));
+        cache.set(vec![]);
+        assert!(cache.get().is_some());
+        std::thread::sleep(Duration::from_millis(70));
+        assert!(cache.get().is_none());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,12 @@ pub struct PerformanceConfig {
     /// Maximum number of consumer groups to fetch offsets for in parallel
     #[serde(default = "default_max_concurrent_groups")]
     pub max_concurrent_groups: usize,
-    /// Maximum number of partitions to fetch watermarks for in parallel
+    /// **Deprecated** since the batched Admin API replaced the per-partition
+    /// watermark fan-out: watermarks are now fetched in two batched
+    /// `ListOffsets` calls regardless of partition count, so a per-partition
+    /// concurrency cap has no effect. Kept in the schema so existing configs
+    /// continue to parse; emits a one-time startup INFO if set to a
+    /// non-default value. Will be removed in a future release.
     #[serde(default = "default_max_concurrent_watermarks")]
     pub max_concurrent_watermarks: usize,
     /// Number of collection cycles between Kafka client recycling.

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,16 @@ pub struct PerformanceConfig {
     /// (refresh every cycle).
     #[serde(with = "humantime_serde", default = "default_metadata_cache_ttl")]
     pub metadata_cache_ttl: Duration,
+    /// How long to cache the list of consumer groups on the cluster.
+    /// `list_consumer_groups` is one RPC per collection cycle; caching
+    /// it shaves off one round trip whenever the set of groups is stable
+    /// (the common case). Newly-created consumer groups become visible
+    /// at most this long after they appear. Set to 0 to disable.
+    #[serde(
+        with = "humantime_serde",
+        default = "default_consumer_groups_cache_ttl"
+    )]
+    pub consumer_groups_cache_ttl: Duration,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -281,6 +291,10 @@ fn default_metadata_cache_ttl() -> Duration {
     Duration::from_secs(300)
 }
 
+fn default_consumer_groups_cache_ttl() -> Duration {
+    Duration::from_secs(60)
+}
+
 fn default_otel_endpoint() -> String {
     "http://localhost:4317".to_string()
 }
@@ -366,6 +380,7 @@ impl Default for PerformanceConfig {
             max_blocking_threads: default_max_blocking_threads(),
             compacted_topics_cache_ttl: default_compacted_topics_cache_ttl(),
             metadata_cache_ttl: default_metadata_cache_ttl(),
+            consumer_groups_cache_ttl: default_consumer_groups_cache_ttl(),
         }
     }
 }
@@ -767,6 +782,10 @@ bootstrap_servers = "localhost:9092"
         assert_eq!(
             config.exporter.performance.metadata_cache_ttl,
             Duration::from_secs(300)
+        );
+        assert_eq!(
+            config.exporter.performance.consumer_groups_cache_ttl,
+            Duration::from_secs(60)
         );
     }
 

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -336,20 +336,38 @@ pub async fn describe_consumer_groups_batched(
         .map(|c| c.iter().map(|s| s.to_string()).collect())
         .collect();
 
+    // Each chunk carries enough identifying context to make partial-
+    // failure warnings actionable: chunk index, chunk size, and the
+    // first / last group id in the chunk.
+    #[derive(Clone)]
+    struct ChunkMeta {
+        index: usize,
+        size: usize,
+        first: String,
+        last: String,
+    }
+
     let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
     let mut handles = Vec::with_capacity(chunks.len());
 
-    for chunk in chunks {
+    for (index, chunk) in chunks.into_iter().enumerate() {
+        let meta = ChunkMeta {
+            index,
+            size: chunk.len(),
+            first: chunk.first().cloned().unwrap_or_default(),
+            last: chunk.last().cloned().unwrap_or_default(),
+        };
         let permit = Arc::clone(&semaphore);
         let admin = Arc::clone(&admin);
         handles.push(tokio::spawn(async move {
             let _permit: tokio::sync::OwnedSemaphorePermit =
                 permit.acquire_owned().await.expect("semaphore closed");
-            tokio::task::spawn_blocking(move || {
+            let result = tokio::task::spawn_blocking(move || {
                 let refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
                 describe_consumer_groups_one_chunk(&admin, &refs, timeout, parse_assignments)
             })
-            .await
+            .await;
+            (meta, result)
         }));
     }
 
@@ -357,15 +375,48 @@ pub async fn describe_consumer_groups_batched(
     let mut out = Vec::with_capacity(group_ids.len());
     for r in results {
         match r {
-            Ok(Ok(Ok(mut part))) => out.append(&mut part),
-            Ok(Ok(Err(e))) => {
-                warn!(error = %e, "DescribeConsumerGroups chunk failed");
+            Ok((_meta, Ok(Ok(mut part)))) => out.append(&mut part),
+            Ok((meta, Ok(Err(e)))) => {
+                warn!(
+                    error = %e,
+                    chunk_index = meta.index,
+                    chunk_size = meta.size,
+                    first_group = %meta.first,
+                    last_group = %meta.last,
+                    "DescribeConsumerGroups chunk failed"
+                );
             }
-            Ok(Err(e)) => {
-                warn!(error = %e, "DescribeConsumerGroups chunk task panicked");
+            Ok((meta, Err(e))) => {
+                // A JoinError from spawn_blocking. Distinguish cancellation
+                // from panic so operators don't chase a bug that wasn't one.
+                let mode = if e.is_cancelled() {
+                    "cancelled"
+                } else if e.is_panic() {
+                    "panicked"
+                } else {
+                    "failed"
+                };
+                warn!(
+                    error = %e,
+                    chunk_index = meta.index,
+                    chunk_size = meta.size,
+                    first_group = %meta.first,
+                    last_group = %meta.last,
+                    "DescribeConsumerGroups chunk task {}",
+                    mode
+                );
             }
             Err(e) => {
-                warn!(error = %e, "DescribeConsumerGroups join error");
+                // Outer tokio::spawn JoinError. Chunk meta is not available
+                // here because the outer task owned it — log what we have.
+                let mode = if e.is_cancelled() {
+                    "cancelled"
+                } else if e.is_panic() {
+                    "panicked"
+                } else {
+                    "failed"
+                };
+                warn!(error = %e, "DescribeConsumerGroups outer task {}", mode);
             }
         }
     }

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -305,30 +305,69 @@ pub struct BatchedMember {
 
 /// Describe consumer groups in batches via `rd_kafka_DescribeConsumerGroups`.
 /// Chunks the input into sub-calls of at most `chunk_size` groups each and
-/// aggregates results. Per-group errors are logged at WARN and the group is
-/// omitted from the returned Vec.
+/// dispatches the chunks concurrently (bounded by `max_concurrent_chunks`).
+/// Per-group errors inside a successful chunk are logged at WARN; a whole
+/// chunk that fails at the FFI/event layer is logged at WARN and the
+/// surviving chunks' results are returned.
 ///
 /// When `parse_assignments = false`, each returned `BatchedMember` has an
 /// empty `assignments: Vec<TopicPartition>`. This skips a per-member
 /// iteration over the assignment's `rd_kafka_topic_partition_list_t` — the
 /// data is only consumed by per-partition metrics (granularity = "partition"),
 /// so it's pure wasted work at the default topic granularity.
-pub fn describe_consumer_groups_batched(
-    admin: &AdminClient<DefaultClientContext>,
+pub async fn describe_consumer_groups_batched(
+    admin: Arc<AdminClient<DefaultClientContext>>,
     group_ids: &[&str],
     timeout: Duration,
     chunk_size: usize,
     parse_assignments: bool,
+    max_concurrent_chunks: usize,
 ) -> Result<Vec<BatchedGroupDescription>> {
     if group_ids.is_empty() {
         return Ok(Vec::new());
     }
     let chunk_size = chunk_size.max(1);
+    let max_concurrent = max_concurrent_chunks.max(1);
+
+    // Own the strings so each spawn_blocking closure can take them without
+    // borrowing from the caller's slice.
+    let chunks: Vec<Vec<String>> = group_ids
+        .chunks(chunk_size)
+        .map(|c| c.iter().map(|s| s.to_string()).collect())
+        .collect();
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
+    let mut handles = Vec::with_capacity(chunks.len());
+
+    for chunk in chunks {
+        let permit = Arc::clone(&semaphore);
+        let admin = Arc::clone(&admin);
+        handles.push(tokio::spawn(async move {
+            let _permit: tokio::sync::OwnedSemaphorePermit =
+                permit.acquire_owned().await.expect("semaphore closed");
+            tokio::task::spawn_blocking(move || {
+                let refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
+                describe_consumer_groups_one_chunk(&admin, &refs, timeout, parse_assignments)
+            })
+            .await
+        }));
+    }
+
+    let results = futures::future::join_all(handles).await;
     let mut out = Vec::with_capacity(group_ids.len());
-    for chunk in group_ids.chunks(chunk_size) {
-        let mut part =
-            describe_consumer_groups_one_chunk(admin, chunk, timeout, parse_assignments)?;
-        out.append(&mut part);
+    for r in results {
+        match r {
+            Ok(Ok(Ok(mut part))) => out.append(&mut part),
+            Ok(Ok(Err(e))) => {
+                warn!(error = %e, "DescribeConsumerGroups chunk failed");
+            }
+            Ok(Err(e)) => {
+                warn!(error = %e, "DescribeConsumerGroups chunk task panicked");
+            }
+            Err(e) => {
+                warn!(error = %e, "DescribeConsumerGroups join error");
+            }
+        }
     }
     Ok(out)
 }

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -198,32 +198,36 @@ impl KafkaClient {
         Ok(groups)
     }
 
-    /// Describe consumer groups via batched `rd_kafka_DescribeConsumerGroups`.
-    /// Replaces the prior sequential `fetch_group_list(Some(group_id))` loop
-    /// which dominated collection time on large clusters (O(groups) serial
-    /// round trips). `protocol_type`/`protocol` fields are not populated — they
-    /// are not consumed downstream (marked `#[allow(dead_code)]`).
-    /// Describe consumer groups via batched FFI. Pass `parse_assignments =
-    /// false` to skip the per-member assignment-parsing step (saves
-    /// O(groups × members × partitions-per-member) work per cycle). The
-    /// data is only consumed by per-partition metrics, so the default
-    /// topic-granularity mode should pass `false`.
+    /// Describe consumer groups via batched FFI. Chunks are fanned out
+    /// concurrently (bounded by `max_concurrent_chunks`) instead of being
+    /// called serially — this was the largest remaining synchronous delay
+    /// in the hot path after Tier 1.
+    ///
+    /// Pass `parse_assignments = false` to skip the per-member
+    /// assignment-parsing step (saves O(groups × members ×
+    /// partitions-per-member) work per cycle). The data is only consumed
+    /// by per-partition metrics, so the default topic-granularity mode
+    /// should pass `false`. `protocol_type`/`protocol` fields are not
+    /// populated — they are not consumed downstream.
     #[instrument(skip(self, group_ids), fields(cluster = %self.config.name, count = group_ids.len()))]
-    pub fn describe_consumer_groups(
+    pub async fn describe_consumer_groups(
         &self,
         group_ids: &[&str],
         parse_assignments: bool,
+        max_concurrent_chunks: usize,
     ) -> Result<Vec<GroupDescription>> {
         use crate::kafka::admin::describe_consumer_groups_batched;
 
         let admin = self.admin();
         let batched = describe_consumer_groups_batched(
-            &admin,
+            admin,
             group_ids,
             self.timeout,
             100,
             parse_assignments,
-        )?;
+            max_concurrent_chunks,
+        )
+        .await?;
 
         Ok(batched
             .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,21 @@ fn main() -> anyhow::Result<()> {
         "Configuration loaded"
     );
 
+    // One-time deprecation notice for config fields that no longer do
+    // anything but are still accepted for backward compatibility.
+    // `max_concurrent_watermarks` was the per-partition fetch_watermarks
+    // concurrency cap; the Tier 1 batched ListOffsets refactor replaced
+    // that fan-out with two broker-level calls, so this knob has no
+    // effect. Only warn when the user explicitly set a non-default value.
+    if config.exporter.performance.max_concurrent_watermarks != 50 {
+        info!(
+            configured_value = config.exporter.performance.max_concurrent_watermarks,
+            "performance.max_concurrent_watermarks is deprecated and has no effect since the \
+             batched Admin API replaced per-partition watermark fetch. Safe to remove from your \
+             config."
+        );
+    }
+
     // Bound the tokio blocking-thread pool. The default (512) commits up to
     // several GB of virtual memory just for native thread stacks; this
     // exporter only needs enough threads to cover concurrent FFI calls from

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,8 @@ fn main() -> anyhow::Result<()> {
     // concurrency cap; the Tier 1 batched ListOffsets refactor replaced
     // that fan-out with two broker-level calls, so this knob has no
     // effect. Only warn when the user explicitly set a non-default value.
-    if config.exporter.performance.max_concurrent_watermarks != 50 {
+    let watermarks_default = crate::config::PerformanceConfig::default().max_concurrent_watermarks;
+    if config.exporter.performance.max_concurrent_watermarks != watermarks_default {
         info!(
             configured_value = config.exporter.performance.max_concurrent_watermarks,
             "performance.max_concurrent_watermarks is deprecated and has no effect since the \


### PR DESCRIPTION
## Summary

Tier 4 of the memory/perf rework. Smaller scope than Tiers 1–3 — this is the structural-cleanup pass: one real perf win (parallelizing the last sequential hot-path operation), one targeted cache, per-phase observability, and a deprecation.

## What changed

### T11 — Parallelize \`DescribeConsumerGroups\` chunks

Tier 1 collapsed the per-group \`fetch_group_list\` loop into chunked batched FFI calls. Those chunks were still issued serially — on a 4K-group cluster at 100/chunk that's 40 sequential RPCs, the largest remaining synchronous delay in the hot path.

- \`admin::describe_consumer_groups_batched\`: sync → async. Each chunk now runs in its own \`tokio::spawn_blocking\`, bounded by a semaphore (reuses \`max_concurrent_groups\`).
- Partial-failure tolerant: failed chunks are logged at WARN, surviving chunks' results returned.
- \`KafkaClient::describe_consumer_groups\`: sync → async; \`OffsetCollector::collect_parallel\` awaits it.

### T12 — TTL cache for \`list_consumer_groups\`

The cluster's consumer-group roster is stable outside of deployments/scaling events. Caching it with a short TTL (60s default) saves one RPC per cycle in steady state; new groups appear within one TTL of creation.

- \`ConsumerGroupsCache\` mirrors \`MetadataCache\` (single Arc-wrapped entry, TTL, zero-TTL-disables)
- Config: \`performance.consumer_groups_cache_ttl\` (default 60s)

### T13 — Per-phase elapsed_ms in the cycle-complete debug log

Adds structured timing fields to the \"Batched collection completed\" debug line: \`list_groups_ms\`, \`describe_groups_ms\`, \`metadata_ms\`, \`watermarks_ms\`, \`group_offsets_ms\`, \`compacted_ms\`. Operators can now see where cycle time goes and the impact of the Tier 2/4 caches directly.

Example from a local test run:
\`\`\`
Cycle 1 (cold):   elapsed_ms=1015 list_groups_ms=1009 describe_groups_ms=1   metadata_ms=0 …
Cycle 2 (warm):   elapsed_ms=3    list_groups_ms=0    describe_groups_ms=1   metadata_ms=0 …
\`\`\`

### T14 — Deprecate \`max_concurrent_watermarks\`

This knob bounded the Tier-0 per-partition \`fetch_watermarks\` fan-out; since Tier 1's batched ListOffsets it has no effect.

- Struct field annotated deprecated with a clear comment
- One-time startup INFO line when the user has explicitly set a non-default value, pointing them to remove it
- Silent at the default (50) so existing deployments never touched stay quiet
- Field still accepted for backward compat; removal deferred to a future release

## Cumulative per-cycle cost, Tier 0 → Tier 4

For a 7K-topic / 19K-partition / 4K-group cluster:

| Phase | Tier 0 | Tier 4 steady state |
|---|---|---|
| list_consumer_groups | 1 RPC | 0 (cached 60s) |
| describe_consumer_groups | 4K serial RPCs | ~40 parallel chunks, each 1 RPC |
| fetch_metadata + filter | full cluster every cycle | 0 (cached 5min) |
| watermarks | 19K per-partition RPCs | 2 batched RPCs |
| ListConsumerGroupOffsets | 4K calls with 19K-partition list each | 4K calls with NULL partitions, parallel |
| fetch_compacted_topics | full-cluster DescribeConfigs | 0 (cached 1h) |
| member-assignment parse | every cycle | 0 at topic granularity (default) |
| TimestampConsumer pool RSS | 5–15 MB × pool_size | 0 (not created in rate mode) |
| Blocking-thread stacks | up to ~4 GB virtual | ≤ ~256 MB (capped) |
| Topic strings | 19K fresh per cycle | ~7K shared \`Arc<str>\` |

## Test plan

- [x] \`cargo build --release\` — exit 0
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — exit 0
- [x] \`cargo test\` — 75/75 pass (3 new tests for ConsumerGroupsCache)
- [x] \`cargo fmt --check\` — exit 0
- [x] Local smoke: phase-timing debug line observed, cycle 2 shows all caches hit (describe_groups_ms=1, everything else 0)
- [x] Deprecation note confirmed silent on default, informative on non-default
- [ ] **Needed**: verify on a real large cluster that describe_groups_ms has dropped significantly vs Tier 3 baseline

## Review pointers

- \`src/kafka/admin.rs\` — \`describe_consumer_groups_batched\` is now async and fans chunks out
- \`src/kafka/client.rs::describe_consumer_groups\` — async signature, passes \`max_concurrent_chunks\` through
- \`src/collector/offset_collector.rs\` — \`ConsumerGroupsCache\` + new cycle-timing instrumentation
- \`src/config.rs\` — new \`consumer_groups_cache_ttl\`, deprecation doc on \`max_concurrent_watermarks\`
- \`src/main.rs\` — one-time deprecation log