### PR TITLE
docs: document timestamp_sampling.mode in test-stack + config example

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -14,14 +14,25 @@ http_host = "0.0.0.0"
 granularity = "topic"
 
 [exporter.timestamp_sampling]
-# Enable time lag calculation via message timestamp fetching
+# Enable time lag calculation
 enabled = true
 
-# Cache timestamp for this duration to avoid excessive Kafka reads
-cache_ttl = "60s"
+# Time-lag estimation mode:
+#   "rate"    - (default) Estimate from observed high-watermark production
+#               rate. No consumer pool, no FFI, scales to any cluster size.
+#   "message" - Read the actual Kafka message at the committed offset and
+#               use its produce timestamp. Exact, but requires a pooled
+#               BaseConsumer per concurrent fetch (~5-15 MB each).
+# mode = "rate"
 
-# Maximum concurrent timestamp fetch operations (each is a full librdkafka client)
+# Message-mode settings (ignored when mode = "rate"):
+cache_ttl = "60s"
 max_concurrent_fetches = 5
+
+# Rate-mode settings (ignored when mode = "message"):
+# rate_history_samples = 5       # watermark observations per partition
+# rate_history_max_age = "10m"   # evict samples older than this
+# rate_min_msgs_per_sec = 0.01   # below this rate → time lag missing
 
 [exporter.performance]
 # Timeout for Kafka API operations (metadata, watermarks, etc.)

--- a/test-stack/DETAILED_GUIDE.md
+++ b/test-stack/DETAILED_GUIDE.md
@@ -216,8 +216,9 @@ granularity = "partition"    # Show partition-level detail
 
 [exporter.timestamp_sampling]
 enabled = true               # Calculate time lag
-cache_ttl = "30s"           # Cache timestamps for 30s
-max_concurrent_fetches = 10  # Parallel timestamp fetches
+mode = "message"             # "rate" (default) or "message" — see README
+cache_ttl = "30s"            # Message-mode: cache timestamps for 30s
+max_concurrent_fetches = 10  # Message-mode: parallel timestamp fetches
 
 [[clusters]]
 name = "test-cluster"

--- a/test-stack/DETAILED_GUIDE.md
+++ b/test-stack/DETAILED_GUIDE.md
@@ -216,9 +216,9 @@ granularity = "partition"    # Show partition-level detail
 
 [exporter.timestamp_sampling]
 enabled = true               # Calculate time lag
-mode = "message"             # "rate" (default) or "message" — see README
+mode = "message"             # "rate" (default) or "message" — see ../README.md (Time Lag Modes)
 cache_ttl = "30s"            # Message-mode: cache timestamps for 30s
-max_concurrent_fetches = 10  # Message-mode: parallel timestamp fetches
+max_concurrent_fetches = 5   # Message-mode: parallel timestamp fetches
 
 [[clusters]]
 name = "test-cluster"

--- a/test-stack/klag-config.toml
+++ b/test-stack/klag-config.toml
@@ -8,8 +8,37 @@ granularity = "partition"
 
 [exporter.timestamp_sampling]
 enabled = true
+
+# How the exporter derives the "seconds of lag" metric.
+#
+# Available modes:
+#   "message" - Reads the actual Kafka message at the consumer's committed
+#               offset and uses its produce timestamp. Exact, but each
+#               laggy partition requires a BaseConsumer pool slot and a
+#               blocking poll() call — significant memory and FFI overhead
+#               on large clusters (5-15 MB per pool slot).
+#
+#   "rate"    - Estimates time lag from the observed rate of change of
+#               high watermarks: time_lag = offset_lag / production_rate.
+#               No consumer pool, no FFI, pure CPU. Accuracy depends on
+#               steady producer rate; good enough for alerting, not
+#               audit-grade. Needs >= 2 collection cycles before producing
+#               a value (first cycle shows no time lag).
+#
+# For the test stack we use "message" so the Grafana dashboards show
+# the exact, lively per-burst time-lag values that demonstrate the
+# exporter's accuracy. Production deployments should default to "rate"
+# for large clusters (lower memory, no pool).
+mode = "message"
+
+# Message-mode settings (ignored when mode = "rate"):
 cache_ttl = "30s"
 max_concurrent_fetches = 5
+
+# Rate-mode settings (ignored when mode = "message"):
+# rate_history_samples = 5       # ring buffer size per partition
+# rate_history_max_age = "10m"   # drop samples older than this
+# rate_min_msgs_per_sec = 0.01   # below this → time lag reported as missing
 
 [exporter.performance]
 client_recycle_interval = 0  # disabled for small test cluster

--- a/test-stack/klag-config.toml
+++ b/test-stack/klag-config.toml
@@ -13,10 +13,10 @@ enabled = true
 #
 # Available modes:
 #   "message" - Reads the actual Kafka message at the consumer's committed
-#               offset and uses its produce timestamp. Exact, but each
-#               laggy partition requires a BaseConsumer pool slot and a
-#               blocking poll() call — significant memory and FFI overhead
-#               on large clusters (5-15 MB per pool slot).
+#               offset and uses its produce timestamp. Exact, but requires
+#               a fixed-size BaseConsumer pool (sized by max_concurrent_fetches)
+#               where each slot is a full librdkafka client (~5-15 MB).
+#               Memory scales with pool size, not partition count.
 #
 #   "rate"    - Estimates time lag from the observed rate of change of
 #               high watermarks: time_lag = offset_lag / production_rate.


### PR DESCRIPTION
Test stack now uses mode='message' so Grafana dashboards show the exact, bursty time-lag curves that demonstrate the exporter's accuracy on the small local cluster. Production deployments should default to mode='rate' for large clusters.

- test-stack/klag-config.toml: full mode comments + message-mode and rate-mode settings clearly separated.
- config.example.toml: updated to match (shows both modes, rate default, message-mode and rate-mode knobs).
- test-stack/DETAILED_GUIDE.md: config snippet updated.