### PR TITLE
chore: release v0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",


### PR DESCRIPTION



## 🤖 New release

* `klag-exporter`: 0.1.21 -> 0.1.22

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.22](https://github.com/softwaremill/klag-exporter/compare/v0.1.21...v0.1.22) - 2026-04-15

### Added

- switch time-lag default to rate-based estimation (Tier 3)
- *(collector)* add RateSampler for rate-based time-lag estimation

### Other

- address Copilot PR feedback (Tier 4)
- max_concurrent_watermarks (no-op since Tier 1 batched ListOffsets)
- *(collector)* per-phase elapsed_ms in the cycle-complete debug log
- *(collector)* TTL cache list_consumer_groups (default 60s)
- *(kafka)* parallelize DescribeConsumerGroups chunks
- address Copilot PR feedback (Tier 3)
- *(readme)* document rate vs message time-lag modes
- address Copilot PR feedback (Tier 2)
- *(kafka)* intern topic names as Arc<str> with per-call dedup
- *(collector)* add TTL cache for filtered monitored-topic set
- *(collector)* add TTL cache for compacted-topic detection
- *(kafka)* skip member-assignment parsing unless granularity=partition
- *(runtime)* cap tokio blocking-thread pool (default 64)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).