### PR TITLE
feat(helm): expose exporter.staleness_threshold

### DIFF
--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
     http_port = {{ .http_port }}
     http_host = {{ .http_host | quote }}
     granularity = {{ .granularity | quote }}
+    {{- if .staleness_threshold }}
+    staleness_threshold = {{ .staleness_threshold | quote }}
+    {{- end }}
     {{- end }}
 
     [exporter.timestamp_sampling]

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -125,6 +125,11 @@ config:
     http_port: 8000
     http_host: "0.0.0.0"
     granularity: "topic"
+    # How long a cluster's metrics remain in /metrics after the last successful
+    # collection before being filtered out. Unset (default) => poll_interval * 3,
+    # which scales automatically with poll_interval. Set explicitly on large
+    # clusters where a single collection cycle can take several minutes.
+    # staleness_threshold: "3m"
   exporter.timestamp_sampling:
     enabled: true
     cache_ttl: "60s"


### PR DESCRIPTION
## Summary
- Adds conditional rendering for `exporter.staleness_threshold` in `configmap.yaml`.
- Adds commented example + docstring in `values.yaml` under `config.exporter`.

Follow-up to #76 (already merged), which added the `staleness_threshold` config field to the code but didn't surface it in the helm chart.

## Behavior
- Operators who don't set `config.exporter.staleness_threshold` get no new rendering — the code's default (`poll_interval × 3`) kicks in, matching the old hard-coded 90s at the default 30s poll interval.
- Operators with long poll intervals (e.g. 4m) can either rely on the new default scaling or pin an explicit duration.

## Changes
- `helm/klag-exporter/templates/configmap.yaml` — `{{- if .staleness_threshold }}` block under `[exporter]`.
- `helm/klag-exporter/values.yaml` — commented `# staleness_threshold: "3m"` with a short rationale.

## Test plan
- [ ] `helm template` against a values file that omits `staleness_threshold` → line is not rendered in the output ConfigMap.
- [ ] `helm template` with `staleness_threshold: "5m"` set → `staleness_threshold = "5m"` appears under `[exporter]`.
- [ ] Deployed exporter starts up and logs the configured threshold at INFO.