### PR TITLE
docs: document exporter.staleness_threshold in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ poll_interval = "30s"
 http_port = 8000
 http_host = "0.0.0.0"
 granularity = "partition"  # "topic" or "partition"
+# Optional. When unset, defaults to poll_interval * 3. Past this age a
+# cluster's metrics are filtered out of /metrics so Prometheus sees a
+# gap instead of a frozen snapshot. Raise it on large clusters where a
+# single collection cycle can take several minutes.
+# staleness_threshold = "3m"
 
 [exporter.timestamp_sampling]
 enabled = true
@@ -561,6 +566,14 @@ client_recycle_interval = 50     # Default: 50 (set 0 to disable)
 | Medium       | 50-200 | 500-2000   | 60s           | 20                     |
 | Large        | 200–1000 | 2000–20000 | 60–120s | 30                     |
 | Very large   | > 1000 | > 20000    | 120–180s      | 50                     |
+
+When you raise `poll_interval`, the staleness threshold that controls how
+long metrics linger in `/metrics` after a successful collection scales
+with it automatically — the default is `poll_interval * 3`, so at
+`poll_interval = 120s` metrics survive for 6 minutes before being
+filtered out as stale. Set `exporter.staleness_threshold` explicitly if
+you want to decouple it from the poll cadence (e.g. pin it to a fixed
+duration for alerting consistency).
 
 ### Additional Recommendations for Large Clusters
 


### PR DESCRIPTION
## Summary
- Adds a commented example of `staleness_threshold` to the main `[exporter]` config block in README.md.
- Adds a paragraph under "Recommended Settings by Cluster Size" explaining that the default auto-scales with `poll_interval` (×3) — important context for operators raising poll interval to 60–180s on large clusters.

Follow-up documentation for #76 (code, merged) and #77 (helm chart, open).

## Why
Operators landing in the large-cluster section to bump `poll_interval` previously had no signal about how the staleness threshold behaves — they might assume it's still 90s and see metrics disappear between cycles. Now they know the default scales automatically and how to override it.

## Test plan
- [x] Markdown renders correctly (visual check).
- [ ] Reviewer sanity-check: the phrasing matches the actual code behaviour (`poll_interval * 3` fallback, `Option<Duration>` override in config).