### PR TITLE
helm: Fix typos and add configuration stub

### DIFF
--- a/helm/klag-exporter/templates/servicemonitor.yaml
+++ b/helm/klag-exporter/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       {{- with .Values.serviceMonitor.additionalEndpointConfig }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-  {{- with .Values.serviceMonitor.additionlConfig }}
+  {{- with .Values.serviceMonitor.additionalConfig }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{ end }}

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -235,5 +235,7 @@ affinity: {}
 
 serviceMonitor:
   enabled: false
-  # Additional cconfig for endpoint
+  # Additional config for endpoint
   additionalEndpointConfig: {}
+  # Additional config for serviceMonitor spec
+  additionalConfig: {}


### PR DESCRIPTION
Fixes a couple of typos and adds a configuration stub for values.serviceMonitor.additionalConfig so that the configuration knob is discoverable.