### PR TITLE
fix(helm): derive containerPort from config.exporter.http_port

### DIFF
--- a/helm/klag-exporter/templates/deployment.yaml
+++ b/helm/klag-exporter/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 8000
+              containerPort: {{ .Values.config.exporter.http_port }}
               protocol: TCP
           {{- with .Values.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
containerPort was hardcoded to 8000 while the app's listen port is set via config.exporter.http_port, so overriding it left the Service's named http targetPort pointing at a dead port.