### PR TITLE
Clippy cleanup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Export all:
+# - (should be) .gitignored
+# - (potentially) secret environment variables
+# - from dotenv-formatted files w/names starting w/`.env`
+DOTENV_FILES="$(find . -maxdepth 1 -type f -name '.env*' -and -not -name '.envrc')"
+for file in ${DOTENV_FILES}; do
+  dotenv "${file}"
+done
+export DOTENV_FILES
+
+# Load nix env for all the cool people
+use flake

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config libcurl4-openssl-dev
 
-      - uses: dtolnay/rust-toolchain@1.93
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config jq libcurl4-openssl-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93
+        uses: dtolnay/rust-toolchain@1.96
 
       - name: Rust version
         id: rust_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config libcurl4-openssl-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93
+        uses: dtolnay/rust-toolchain@1.96
 
       - name: Run release-plz
         uses: release-plz/action@v0.5

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .claude
 .idea/
 CLAUDE.md
+.direnv/
+result*
+.env*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 # Install build dependencies for rdkafka
 RUN apt-get update && apt-get install -y \

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782443907,
+        "narHash": "sha256-P+pADLtK7qC1mz0/5Xq9uF77oahUR4zYLTaitiHsUHg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4b06ff4acf3491ff69721df852507fcc51d0a13d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ (import inputs.rust-overlay) ];
+        };
+        inherit (pkgs) lib;
+        cargoToml = lib.fromTOML (lib.readFile ./Cargo.toml);
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "clippy"
+            "rust-analyzer"
+            "rust-src"
+            "rustfmt"
+          ];
+        };
+
+        klag-exporter =
+          (pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          }).buildRustPackage
+            {
+              pname = cargoToml.package.name;
+              version = "${cargoToml.package.version}-${
+                if lib.hasAttr "rev" inputs.self then
+                  "${lib.toString inputs.self.revCount}-${inputs.self.shortRev}"
+                else
+                  "gitDirty"
+              }";
+
+              src = lib.cleanSource ./.;
+              cargoLock.lockFile = ./Cargo.lock;
+              LIBCLANG_PATH = "${lib.makeLibraryPath [ pkgs.libclang ]}";
+
+              buildInputs = [
+                pkgs.openssl
+                pkgs.jemalloc
+                pkgs.cyrus_sasl
+                pkgs.curl
+              ];
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                pkgs.cmake
+              ];
+            };
+      in
+      {
+        checks = { inherit klag-exporter; };
+        devShells.default = pkgs.mkShell {
+          hardeningDisable = [ "fortify" ];
+          LIBCLANG_PATH = "${lib.makeLibraryPath [ pkgs.libclang ]}"; # for dev builds
+          inputsFrom = [ klag-exporter ];
+          packages = with pkgs; [
+            cargo-watch
+          ];
+        };
+        packages = {
+          inherit klag-exporter;
+          default = klag-exporter;
+        };
+      }
+    );
+}

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, instrument, warn};
 
-/// Default timeout for a single collection cycle (should be less than poll_interval)
-const DEFAULT_COLLECTION_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default timeout for a single collection cycle (should be less than `poll_interval`)
+const DEFAULT_COLLECTION_TIMEOUT: Duration = Duration::from_mins(1);
 
 pub struct ClusterManager {
     cluster_name: String,
@@ -34,7 +34,7 @@ pub struct ClusterManager {
 
 impl ClusterManager {
     pub fn new(
-        config: ClusterConfig,
+        config: &ClusterConfig,
         registry: Arc<MetricsRegistry>,
         exporter_config: &ExporterConfig,
     ) -> Result<Self> {
@@ -43,11 +43,11 @@ impl ClusterManager {
         let filters = config.compile_filters()?;
         let performance = exporter_config.performance.clone();
 
-        let client = Arc::new(KafkaClient::with_performance(&config, performance.clone())?);
+        let client = Arc::new(KafkaClient::with_performance(config, performance.clone())?);
         let offset_collector = OffsetCollector::with_performance(
             Arc::clone(&client),
             filters,
-            performance.clone(),
+            performance,
             exporter_config.granularity,
         );
 
@@ -59,7 +59,7 @@ impl ClusterManager {
                     // the Tier-3 resident-memory saving for rate-mode users:
                     // no BaseConsumer pool, no extra librdkafka clients.
                     let ts_consumer =
-                        TimestampConsumer::with_pool_size(&config, ts_cfg.max_concurrent_fetches)?;
+                        TimestampConsumer::with_pool_size(config, ts_cfg.max_concurrent_fetches)?;
                     TimestampSampler::new_message(ts_consumer, ts_cfg.cache_ttl)
                 }
                 crate::config::TimestampSamplingMode::Rate => {
@@ -101,7 +101,7 @@ impl ClusterManager {
             timestamp_sampler,
             registry,
             poll_interval: exporter_config.poll_interval,
-            max_backoff: Duration::from_secs(300),
+            max_backoff: Duration::from_mins(5),
             granularity: exporter_config.granularity,
             max_concurrent_fetches: exporter_config.timestamp_sampling.max_concurrent_fetches,
             cache_cleanup_interval: exporter_config.timestamp_sampling.cache_ttl * 2,
@@ -308,7 +308,7 @@ impl ClusterManager {
         // Update registry with granularity and custom labels
         self.registry.update_with_options(
             &self.cluster_name,
-            lag_metrics,
+            &lag_metrics,
             self.granularity,
             &self.cluster_labels,
         );
@@ -320,7 +320,7 @@ impl ClusterManager {
         debug!(
             cluster = %self.cluster_name,
             elapsed_ms = scrape_duration_ms,
-            timestamp_cache_size = self.timestamp_sampler.as_ref().map(|s| s.cache_size()).unwrap_or(0),
+            timestamp_cache_size = self.timestamp_sampler.as_ref().map_or(0, super::super::collector::timestamp_sampler::TimestampSampler::cache_size),
             "Collection cycle completed"
         );
 

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -31,11 +31,11 @@ pub struct PartitionLagMetric {
     pub lag_seconds: Option<f64>,
     /// Whether compaction was detected for this partition's timestamp fetch
     pub compaction_detected: bool,
-    /// Whether data loss occurred (committed_offset < low_watermark)
+    /// Whether data loss occurred (`committed_offset` < `low_watermark`)
     pub data_loss_detected: bool,
-    /// Number of messages lost to retention (low_watermark - committed_offset when positive)
+    /// Number of messages lost to retention (`low_watermark` - `committed_offset` when positive)
     pub messages_lost: i64,
-    /// Offset distance to deletion boundary (committed_offset - low_watermark)
+    /// Offset distance to deletion boundary (`committed_offset` - `low_watermark`)
     pub retention_margin: i64,
     /// Percentage of retention window occupied by lag (0=caught up, 100=at boundary, >100=data loss)
     pub lag_retention_ratio: f64,
@@ -72,10 +72,10 @@ pub struct LagCalculator;
 
 /// Encode consumer group state as an integer.
 ///
-/// The string values come from Kafka's DescribeGroups response and match
+/// The string values come from Kafka's `DescribeGroups` response and match
 /// `org.apache.kafka.common.ConsumerGroupState` exactly.
 ///
-/// Classic protocol states: PreparingRebalance, CompletingRebalance, Stable, Dead, Empty
+/// Classic protocol states: `PreparingRebalance`, `CompletingRebalance`, Stable, Dead, Empty
 /// KIP-848 protocol states: Assigning, Reconciling, Stable, Dead, Empty
 ///
 /// Mapping:
@@ -158,16 +158,16 @@ impl LagCalculator {
                 };
 
                 // Look up member info for this partition
-                let (member_host, consumer_id, client_id) = member_map
-                    .get(tp)
-                    .map(|m| {
+                let (member_host, consumer_id, client_id) = member_map.get(tp).map_or_else(
+                    || (String::new(), String::new(), String::new()),
+                    |m| {
                         (
                             m.client_host.to_string(),
                             m.member_id.to_string(),
                             m.client_id.to_string(),
                         )
-                    })
-                    .unwrap_or_else(|| (String::new(), String::new(), String::new()));
+                    },
+                );
 
                 // Calculate time lag if timestamp available
                 let ts_data = timestamps.get(&(group.group_id.clone(), tp.clone()));

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -13,7 +13,7 @@ use tracing::{debug, instrument, warn};
 /// caching it with a long TTL saves a per-cycle `DescribeConfigs` over the
 /// monitored topic set. On each cycle the collector asks the cache which
 /// topics still need to be queried fresh, then merges the cached-true
-/// entries with whatever DescribeConfigs returns.
+/// entries with whatever `DescribeConfigs` returns.
 struct CompactedTopicsCache {
     ttl: Duration,
     // (is_compacted, fetched_at). Mutex is fine — accessed only from
@@ -31,10 +31,13 @@ impl CompactedTopicsCache {
 
     /// Split `monitored_topics` into:
     ///   - `cached_compacted` — topics the cache says are compacted (fresh)
-    ///   - `to_fetch` — topics with no fresh cache entry (need DescribeConfigs)
+    ///   - `to_fetch` — topics with no fresh cache entry (need `DescribeConfigs`)
     fn partition<'a>(&self, monitored_topics: &'a [String]) -> (HashSet<String>, Vec<&'a str>) {
         let now = Instant::now();
-        let entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        let entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let mut cached_compacted = HashSet::new();
         let mut to_fetch: Vec<&str> = Vec::new();
@@ -55,7 +58,10 @@ impl CompactedTopicsCache {
     /// in `fetched_topics`, record whether it appeared in `compacted_result`.
     fn update(&self, fetched_topics: &[&str], compacted_result: &HashSet<String>) {
         let now = Instant::now();
-        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for topic in fetched_topics {
             let is_compacted = compacted_result.contains(*topic);
             entries.insert((*topic).to_string(), (is_compacted, now));
@@ -64,8 +70,14 @@ impl CompactedTopicsCache {
 
     /// Drop cache entries for topics no longer being monitored.
     fn prune_to(&self, monitored_topics: &[String]) {
-        let keep: HashSet<&str> = monitored_topics.iter().map(|s| s.as_str()).collect();
-        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        let keep: HashSet<&str> = monitored_topics
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         entries.retain(|k, _| keep.contains(k.as_str()));
     }
 }
@@ -84,7 +96,7 @@ struct MetadataCache {
 }
 
 impl MetadataCache {
-    fn new(ttl: Duration) -> Self {
+    const fn new(ttl: Duration) -> Self {
         Self {
             ttl,
             entry: Mutex::new(None),
@@ -95,7 +107,10 @@ impl MetadataCache {
         if self.ttl.is_zero() {
             return None;
         }
-        let guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+        let guard = self
+            .entry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (set, at) = guard.as_ref()?;
         if at.elapsed() < self.ttl {
             Some((Arc::clone(&set.0), Arc::clone(&set.1)))
@@ -111,7 +126,10 @@ impl MetadataCache {
     fn set(&self, partitions: Vec<TopicPartition>, topics: Vec<String>) -> MonitoredSet {
         let set: MonitoredSet = (Arc::new(partitions), Arc::new(topics));
         if !self.ttl.is_zero() {
-            let mut guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+            let mut guard = self
+                .entry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             *guard = Some(((Arc::clone(&set.0), Arc::clone(&set.1)), Instant::now()));
         }
         set
@@ -129,7 +147,7 @@ struct ConsumerGroupsCache {
 }
 
 impl ConsumerGroupsCache {
-    fn new(ttl: Duration) -> Self {
+    const fn new(ttl: Duration) -> Self {
         Self {
             ttl,
             entry: Mutex::new(None),
@@ -140,7 +158,10 @@ impl ConsumerGroupsCache {
         if self.ttl.is_zero() {
             return None;
         }
-        let guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+        let guard = self
+            .entry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let (groups, at) = guard.as_ref()?;
         if at.elapsed() < self.ttl {
             Some(Arc::clone(groups))
@@ -152,7 +173,10 @@ impl ConsumerGroupsCache {
     fn set(&self, groups: Vec<ConsumerGroupInfo>) -> Arc<Vec<ConsumerGroupInfo>> {
         let arc = Arc::new(groups);
         if !self.ttl.is_zero() {
-            let mut guard = self.entry.lock().unwrap_or_else(|p| p.into_inner());
+            let mut guard = self
+                .entry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             *guard = Some((Arc::clone(&arc), Instant::now()));
         }
         arc
@@ -190,7 +214,7 @@ pub struct OffsetsSnapshot {
     /// Topics configured with `cleanup.policy=compact`. Populated by
     /// `collect_parallel` for the monitored topic set. Used by the lag
     /// calculator to suppress data-loss warnings on compacted topics (where
-    /// low_watermark ahead of committed_offset is expected, not a loss).
+    /// `low_watermark` ahead of `committed_offset` is expected, not a loss).
     pub compacted_topics: HashSet<String>,
     #[allow(dead_code)]
     pub timestamp_ms: i64,
@@ -238,15 +262,15 @@ impl OffsetCollector {
     /// the watermark + compacted-topic-config path.
     ///
     /// Per-cycle RPC count:
-    ///   - 2 batched ListOffsets calls (EARLIEST + LATEST), routed per leader
+    ///   - 2 batched `ListOffsets` calls (EARLIEST + LATEST), routed per leader
     ///     broker internally — O(brokers) broker round trips regardless of
     ///     partition count.
-    ///   - `ceil(groups / 100)` batched DescribeConsumerGroups calls.
-    ///   - 1 ListConsumerGroupOffsets call per group (`PER_CALL_CHUNK = 1`
+    ///   - `ceil(groups / 100)` batched `DescribeConsumerGroups` calls.
+    ///   - 1 `ListConsumerGroupOffsets` call per group (`PER_CALL_CHUNK = 1`
     ///     in `fetch_all_group_offsets_batched` because librdkafka 2.12
     ///     rejects multi-group calls at the client layer; fanned out via
     ///     `max_concurrent_groups`).
-    ///   - 1 DescribeConfigs call restricted to monitored topics.
+    ///   - 1 `DescribeConfigs` call restricted to monitored topics.
     #[instrument(skip(self), fields(cluster = %self.client.cluster_name()))]
     pub async fn collect_parallel(&self) -> Result<OffsetsSnapshot> {
         let start = std::time::Instant::now();
@@ -350,13 +374,21 @@ impl OffsetCollector {
         // refresh new topics (or nothing at all in steady state).
         let phase_start = std::time::Instant::now();
         let (mut compacted_topics, to_fetch) = self.compacted_cache.partition(&monitored_topics);
-        if !to_fetch.is_empty() {
+        if to_fetch.is_empty() {
+            debug!(
+                cached = compacted_topics.len(),
+                "Compacted-topic cache fully hit — no DescribeConfigs RPC"
+            );
+        } else {
             debug!(
                 to_fetch = to_fetch.len(),
                 cached = compacted_topics.len(),
                 "Compacted-topic cache partial miss — refreshing"
             );
-            let to_fetch_owned: Vec<String> = to_fetch.iter().map(|s| s.to_string()).collect();
+            let to_fetch_owned: Vec<String> = to_fetch
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
             match self
                 .client
                 .fetch_compacted_topics_for(&to_fetch_owned)
@@ -368,11 +400,6 @@ impl OffsetCollector {
                 }
                 Err(e) => warn!(error = %e, "Failed to refresh compacted topics"),
             }
-        } else {
-            debug!(
-                cached = compacted_topics.len(),
-                "Compacted-topic cache fully hit — no DescribeConfigs RPC"
-            );
         }
         // Drop cache entries for topics no longer monitored (filter change,
         // topic deletion) so memory doesn't grow unboundedly.
@@ -472,9 +499,9 @@ impl OffsetCollector {
     /// Fetch offsets for all groups via batched Admin API.
     ///
     /// librdkafka 2.12's `rd_kafka_ListConsumerGroupOffsets` rejects calls with
-    /// more than one group per call ("Exactly one ListConsumerGroupOffsets must
+    /// more than one group per call ("Exactly one `ListConsumerGroupOffsets` must
     /// be passed") even though the Kafka protocol supports multi-group
-    /// ListOffsetFetch (KIP-709). We therefore issue one FFI call per group,
+    /// `ListOffsetFetch` (KIP-709). We therefore issue one FFI call per group,
     /// fanned out with bounded concurrency via `max_concurrent_groups`.
     ///
     /// The win vs. the prior path is not "multi-group in one call" but:
@@ -543,10 +570,10 @@ impl OffsetCollector {
             match r {
                 Ok((_gid, Ok(Ok(map)))) => merged.extend(map),
                 Ok((gid, Ok(Err(e)))) => {
-                    warn!(group = %gid, error = %e, "Group-offset call failed")
+                    warn!(group = %gid, error = %e, "Group-offset call failed");
                 }
                 Ok((gid, Err(e))) => {
-                    warn!(group = %gid, error = %e, "Group-offset call task panicked")
+                    warn!(group = %gid, error = %e, "Group-offset call task panicked");
                 }
                 Err(e) => warn!(error = %e, "Group-offset join error"),
             }

--- a/src/collector/rate_sampler.rs
+++ b/src/collector/rate_sampler.rs
@@ -4,7 +4,7 @@
 //! at the consumer's committed offset and subtract its produce timestamp from
 //! "now". That works but it scales poorly on large clusters: every laggy
 //! partition requires a full `assign()` + `poll()` round trip through a
-//! librdkafka BaseConsumer, and the consumer pool itself occupies tens to
+//! librdkafka `BaseConsumer`, and the consumer pool itself occupies tens to
 //! hundreds of MB of resident memory (each `BaseConsumer` is a full
 //! librdkafka client with its own metadata cache and background threads).
 //!
@@ -33,7 +33,7 @@ struct WatermarkSample {
 }
 
 /// Shared rate-computation helper. Returns `None` if < 2 samples, Δtime
-/// ≤ 0, Δhigh_watermark ≤ 0 (retention rewind), or rate below floor.
+/// ≤ 0, `Δhigh_watermark` ≤ 0 (retention rewind), or rate below floor.
 fn compute_rate(buf: &VecDeque<WatermarkSample>, min_msgs_per_sec: f64) -> Option<f64> {
     if buf.len() < 2 {
         return None;
@@ -80,7 +80,10 @@ impl RateSampler {
     /// no longer present in `watermarks` (topic deleted / filter change).
     pub fn record_watermarks(&self, watermarks: &HashMap<TopicPartition, (i64, i64)>) {
         let now = Instant::now();
-        let mut history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        let mut history = self
+            .history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         // Drop entries for partitions no longer being monitored.
         history.retain(|tp, _| watermarks.contains_key(tp));
@@ -118,7 +121,10 @@ impl RateSampler {
         if lag <= 0 {
             return Some(0.0);
         }
-        let history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        let history = self
+            .history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         compute_rate(history.get(tp)?, self.min_msgs_per_sec).map(|rate| lag as f64 / rate)
     }
 
@@ -133,20 +139,27 @@ impl RateSampler {
     /// available this cycle (insufficient samples, below floor, or
     /// retention rewind).
     pub fn rates_snapshot(&self) -> HashMap<TopicPartition, f64> {
-        let history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        let history = self
+            .history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut out = HashMap::with_capacity(history.len());
         for (tp, buf) in history.iter() {
             if let Some(rate) = compute_rate(buf, self.min_msgs_per_sec) {
                 out.insert(tp.clone(), rate);
             }
         }
+        drop(history);
         out
     }
 
     /// Current number of partitions with history entries. Used for
     /// diagnostics / metrics.
     pub fn tracked_partitions(&self) -> usize {
-        self.history.lock().unwrap_or_else(|p| p.into_inner()).len()
+        self.history
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
     }
 
     /// Drop all history. Used when a cluster-wide reset is needed (e.g.
@@ -156,7 +169,7 @@ impl RateSampler {
     pub fn clear(&self) {
         self.history
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clear();
     }
 }

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -3,7 +3,7 @@
 //! Two modes:
 //!
 //! 1. **`Message`** — read the actual message at the committed offset via a
-//!    pooled BaseConsumer and use its produce timestamp. Exact, but the
+//!    pooled `BaseConsumer` and use its produce timestamp. Exact, but the
 //!    pool is a heavyweight native-memory consumer on large clusters
 //!    (each `BaseConsumer` is a full librdkafka client with its own
 //!    metadata cache and background threads).
@@ -203,8 +203,7 @@ fn compute_time_lags_rate(
         for (tp, committed_offset) in &group.offsets {
             let high = snapshot
                 .get_watermark(tp)
-                .map(|(_, h)| h)
-                .unwrap_or(*committed_offset);
+                .map_or(*committed_offset, |(_, h)| h);
             let lag = high - *committed_offset;
             if lag <= 0 {
                 // 0 lag → 0 seconds. Downstream builds Some(0.0) naturally;
@@ -245,8 +244,7 @@ async fn compute_time_lags_message(
         for (tp, committed_offset) in &group.offsets {
             let high = snapshot
                 .get_watermark(tp)
-                .map(|(_, h)| h)
-                .unwrap_or(*committed_offset);
+                .map_or(*committed_offset, |(_, h)| h);
             if high - *committed_offset > 0 {
                 requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ pub enum Granularity {
 #[serde(rename_all = "lowercase")]
 pub enum TimestampSamplingMode {
     /// Read the actual message at the committed offset via a pooled
-    /// BaseConsumer and use its produce timestamp. Exact, but the pool
+    /// `BaseConsumer` and use its produce timestamp. Exact, but the pool
     /// occupies meaningful resident memory and creates per-cycle FFI
     /// churn on large clusters.
     Message,
@@ -80,7 +80,7 @@ pub struct TimestampSamplingConfig {
     /// `rate` mode (rate mode does no I/O).
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: usize,
-    /// `rate` mode: maximum number of (time, high_watermark) samples
+    /// `rate` mode: maximum number of (time, `high_watermark`) samples
     /// retained per partition. Larger = smoother rate estimate, more
     /// memory. Default 5.
     #[serde(default = "default_rate_history_samples")]
@@ -190,14 +190,14 @@ pub struct LeadershipConfig {
     /// Namespace for the Lease resource. Supports env var substitution.
     #[serde(default = "default_lease_namespace")]
     pub lease_namespace: String,
-    /// Identity of this instance. Defaults to HOSTNAME or POD_NAME env var.
+    /// Identity of this instance. Defaults to HOSTNAME or `POD_NAME` env var.
     #[allow(dead_code)] // Used by kubernetes feature
     pub identity: Option<String>,
     /// Duration the lease is valid in seconds.
     #[serde(default = "default_lease_duration")]
     #[allow(dead_code)] // Used by kubernetes feature
     pub lease_duration_secs: u32,
-    /// Grace period for lease renewal in seconds. Must be less than lease_duration.
+    /// Grace period for lease renewal in seconds. Must be less than `lease_duration`.
     #[serde(default = "default_grace_period")]
     #[allow(dead_code)] // Used by kubernetes feature
     pub grace_period_secs: u32,
@@ -228,11 +228,11 @@ pub struct ClusterConfig {
     pub labels: HashMap<String, String>,
 }
 
-fn default_poll_interval() -> Duration {
+const fn default_poll_interval() -> Duration {
     Duration::from_secs(30)
 }
 
-fn default_http_port() -> u16 {
+const fn default_http_port() -> u16 {
     8000
 }
 
@@ -240,83 +240,83 @@ fn default_http_host() -> String {
     "0.0.0.0".to_string()
 }
 
-fn default_granularity() -> Granularity {
+const fn default_granularity() -> Granularity {
     Granularity::Topic
 }
 
-fn default_true() -> bool {
+const fn default_true() -> bool {
     true
 }
 
-fn default_cache_ttl() -> Duration {
-    Duration::from_secs(60)
+const fn default_cache_ttl() -> Duration {
+    Duration::from_mins(1)
 }
 
-fn default_max_concurrent_fetches() -> usize {
+const fn default_max_concurrent_fetches() -> usize {
     5
 }
 
-fn default_timestamp_sampling_mode() -> TimestampSamplingMode {
+const fn default_timestamp_sampling_mode() -> TimestampSamplingMode {
     TimestampSamplingMode::Rate
 }
 
-fn default_rate_history_samples() -> usize {
+const fn default_rate_history_samples() -> usize {
     5
 }
 
-fn default_rate_history_max_age() -> Duration {
-    Duration::from_secs(600)
+const fn default_rate_history_max_age() -> Duration {
+    Duration::from_mins(10)
 }
 
-fn default_rate_min_msgs_per_sec() -> f64 {
+const fn default_rate_min_msgs_per_sec() -> f64 {
     0.01
 }
 
-fn default_kafka_timeout() -> Duration {
+const fn default_kafka_timeout() -> Duration {
     Duration::from_secs(30)
 }
 
-fn default_offset_fetch_timeout() -> Duration {
+const fn default_offset_fetch_timeout() -> Duration {
     Duration::from_secs(10)
 }
 
-fn default_max_concurrent_groups() -> usize {
+const fn default_max_concurrent_groups() -> usize {
     10
 }
 
-fn default_max_concurrent_watermarks() -> usize {
+const fn default_max_concurrent_watermarks() -> usize {
     50
 }
 
-fn default_client_recycle_interval() -> u64 {
+const fn default_client_recycle_interval() -> u64 {
     50
 }
 
-fn default_max_blocking_threads() -> usize {
+const fn default_max_blocking_threads() -> usize {
     64
 }
 
-fn default_compacted_topics_cache_ttl() -> Duration {
-    Duration::from_secs(3600)
+const fn default_compacted_topics_cache_ttl() -> Duration {
+    Duration::from_hours(1)
 }
 
-fn default_metadata_cache_ttl() -> Duration {
-    Duration::from_secs(300)
+const fn default_metadata_cache_ttl() -> Duration {
+    Duration::from_mins(5)
 }
 
-fn default_consumer_groups_cache_ttl() -> Duration {
-    Duration::from_secs(60)
+const fn default_consumer_groups_cache_ttl() -> Duration {
+    Duration::from_mins(1)
 }
 
 fn default_otel_endpoint() -> String {
     "http://localhost:4317".to_string()
 }
 
-fn default_export_interval() -> Duration {
-    Duration::from_secs(60)
+const fn default_export_interval() -> Duration {
+    Duration::from_mins(1)
 }
 
-fn default_leadership_provider() -> LeadershipProvider {
+const fn default_leadership_provider() -> LeadershipProvider {
     LeadershipProvider::Kubernetes
 }
 
@@ -328,11 +328,11 @@ fn default_lease_namespace() -> String {
     "default".to_string()
 }
 
-fn default_lease_duration() -> u32 {
+const fn default_lease_duration() -> u32 {
     15
 }
 
-fn default_grace_period() -> u32 {
+const fn default_grace_period() -> u32 {
     5
 }
 
@@ -399,21 +399,20 @@ impl Default for PerformanceConfig {
 }
 
 impl Config {
-    pub fn load(path: Option<&str>) -> Result<Config> {
+    pub fn load(path: Option<&str>) -> Result<Self> {
         let config_path = path.unwrap_or("config.toml");
 
         if !Path::new(config_path).exists() {
             return Err(KlagError::Config(format!(
-                "Configuration file not found: {}",
-                config_path
+                "Configuration file not found: {config_path}"
             )));
         }
 
         let content = std::fs::read_to_string(config_path)?;
         let content = Self::substitute_env_vars(&content);
 
-        let config: Config = toml::from_str(&content)
-            .map_err(|e| KlagError::Config(format!("TOML parse error: {}", e)))?;
+        let config: Self = toml::from_str(&content)
+            .map_err(|e| KlagError::Config(format!("TOML parse error: {e}")))?;
 
         config.validate()?;
         Ok(config)
@@ -427,7 +426,7 @@ impl Config {
         let re = Regex::new(r"\$\{\??([^}:-]+)(?::-([^}]*))?\}").unwrap();
         re.replace_all(content, |caps: &regex::Captures| {
             let var_name = &caps[1];
-            let default_value = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+            let default_value = caps.get(2).map_or("", |m| m.as_str());
             std::env::var(var_name).unwrap_or_else(|_| default_value.to_string())
         })
         .to_string()

--- a/src/export/prometheus.rs
+++ b/src/export/prometheus.rs
@@ -6,7 +6,7 @@ pub struct PrometheusExporter {
 }
 
 impl PrometheusExporter {
-    pub fn new(registry: Arc<MetricsRegistry>) -> Self {
+    pub const fn new(registry: Arc<MetricsRegistry>) -> Self {
         Self { registry }
     }
 
@@ -79,7 +79,7 @@ mod tests {
             data_loss_partition_count: 0,
         };
 
-        registry.update("test", metrics);
+        registry.update("test", &metrics);
 
         let exporter = PrometheusExporter::new(registry);
         let output = exporter.render_metrics();

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -35,9 +35,7 @@ impl HttpServer {
         registry: Arc<MetricsRegistry>,
         leadership: LeadershipStatus,
     ) -> Self {
-        let addr: SocketAddr = format!("{}:{}", host, port)
-            .parse()
-            .expect("Invalid address");
+        let addr: SocketAddr = format!("{host}:{port}").parse().expect("Invalid address");
 
         Self {
             addr,

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -13,7 +13,31 @@
 use crate::error::{KlagError, Result};
 use crate::kafka::client::TopicPartition;
 use rdkafka::admin::AdminClient;
-use rdkafka::bindings::*;
+use rdkafka::bindings::{
+    rd_kafka_AdminOptions_destroy, rd_kafka_AdminOptions_new,
+    rd_kafka_AdminOptions_set_request_timeout, rd_kafka_AdminOptions_t,
+    rd_kafka_ConsumerGroupDescription_error, rd_kafka_ConsumerGroupDescription_group_id,
+    rd_kafka_ConsumerGroupDescription_member, rd_kafka_ConsumerGroupDescription_member_count,
+    rd_kafka_ConsumerGroupDescription_state, rd_kafka_DescribeConsumerGroups,
+    rd_kafka_DescribeConsumerGroups_result_groups, rd_kafka_ListConsumerGroupOffsets,
+    rd_kafka_ListConsumerGroupOffsets_destroy, rd_kafka_ListConsumerGroupOffsets_new,
+    rd_kafka_ListConsumerGroupOffsets_result_groups, rd_kafka_ListConsumerGroupOffsets_t,
+    rd_kafka_ListOffsets, rd_kafka_ListOffsetsResultInfo_topic_partition,
+    rd_kafka_ListOffsets_result_infos, rd_kafka_MemberAssignment_partitions,
+    rd_kafka_MemberDescription_assignment, rd_kafka_MemberDescription_client_id,
+    rd_kafka_MemberDescription_consumer_id, rd_kafka_MemberDescription_host, rd_kafka_OffsetSpec_t,
+    rd_kafka_admin_op_t, rd_kafka_consumer_group_state_name, rd_kafka_err2name,
+    rd_kafka_error_code, rd_kafka_error_string, rd_kafka_event_DescribeConsumerGroups_result,
+    rd_kafka_event_ListConsumerGroupOffsets_result, rd_kafka_event_ListOffsets_result,
+    rd_kafka_event_destroy, rd_kafka_event_error, rd_kafka_event_error_string, rd_kafka_event_t,
+    rd_kafka_event_type, rd_kafka_group_result_error, rd_kafka_group_result_name,
+    rd_kafka_group_result_partitions, rd_kafka_queue_destroy, rd_kafka_queue_new,
+    rd_kafka_queue_poll, rd_kafka_queue_t, rd_kafka_resp_err_t, rd_kafka_t,
+    rd_kafka_topic_partition_list_add, rd_kafka_topic_partition_list_destroy,
+    rd_kafka_topic_partition_list_new, rd_kafka_topic_partition_list_t,
+    RD_KAFKA_EVENT_DESCRIBECONSUMERGROUPS_RESULT, RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT,
+    RD_KAFKA_EVENT_LISTOFFSETS_RESULT,
+};
 use rdkafka::client::DefaultClientContext;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -57,29 +81,29 @@ pub enum OffsetSpec {
 }
 
 impl OffsetSpec {
-    fn as_c_value(self) -> i64 {
+    const fn as_c_value(self) -> i64 {
         match self {
-            OffsetSpec::Earliest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_EARLIEST as i64,
-            OffsetSpec::Latest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_LATEST as i64,
+            Self::Earliest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_EARLIEST as i64,
+            Self::Latest => rd_kafka_OffsetSpec_t::RD_KAFKA_OFFSET_SPEC_LATEST as i64,
         }
     }
 }
 
 /// Copy the librdkafka errstr buffer out as a String.
-pub(crate) fn errstr_to_string(buf: &[c_char]) -> String {
+pub fn errstr_to_string(buf: &[c_char]) -> String {
     // SAFETY: librdkafka null-terminates; buf is a stack array owned by caller.
     unsafe { CStr::from_ptr(buf.as_ptr()).to_string_lossy().to_string() }
 }
 
-/// Build a C cstring from a Rust &str, returning a KlagError on embedded NULs.
-pub(crate) fn cstring_or_err(s: &str) -> Result<CString> {
+/// Build a C cstring from a Rust &str, returning a `KlagError` on embedded NULs.
+pub fn cstring_or_err(s: &str) -> Result<CString> {
     CString::new(s).map_err(|e| KlagError::Admin(format!("Invalid C string '{s}': {e}")))
 }
 
 /// Keep the admin client alive for the duration of an FFI call. This type is
 /// intentionally opaque: callers pass `&AdminClient` and we hold references
 /// that must not outlive it.
-pub(crate) fn admin_native_ptr(admin: &AdminClient<DefaultClientContext>) -> *mut rd_kafka_t {
+pub fn admin_native_ptr(admin: &AdminClient<DefaultClientContext>) -> *mut rd_kafka_t {
     admin.inner().native_ptr()
 }
 
@@ -108,7 +132,7 @@ pub fn list_offsets_batched(
         options: *mut rd_kafka_AdminOptions_t,
         queue: *mut rd_kafka_queue_t,
         event: *mut rd_kafka_event_t,
-        _topic_cstrings: Vec<CString>,
+        topic_cstrings: Vec<CString>,
     }
     impl Drop for Cleanup {
         fn drop(&mut self) {
@@ -143,14 +167,14 @@ pub fn list_offsets_batched(
             options: ptr::null_mut(),
             queue: ptr::null_mut(),
             event: ptr::null_mut(),
-            _topic_cstrings: Vec::with_capacity(partitions.len()),
+            topic_cstrings: Vec::with_capacity(partitions.len()),
         };
 
         let spec_value = spec.as_c_value();
         for tp in partitions {
             let topic_cstr = cstring_or_err(&tp.topic)?;
-            cleanup._topic_cstrings.push(topic_cstr);
-            let cstr_ptr = cleanup._topic_cstrings.last().unwrap().as_ptr();
+            cleanup.topic_cstrings.push(topic_cstr);
+            let cstr_ptr = cleanup.topic_cstrings.last().unwrap().as_ptr();
             let elem = rd_kafka_topic_partition_list_add(c_tpl, cstr_ptr, tp.partition);
             if elem.is_null() {
                 return Err(KlagError::Admin(
@@ -224,7 +248,7 @@ pub fn list_offsets_batched(
         }
 
         let mut n_infos: usize = 0;
-        let infos_ptr = rd_kafka_ListOffsets_result_infos(result, &mut n_infos);
+        let infos_ptr = rd_kafka_ListOffsets_result_infos(result, &raw mut n_infos);
         let mut out = HashMap::with_capacity(n_infos);
 
         if infos_ptr.is_null() || n_infos == 0 {
@@ -333,7 +357,7 @@ pub async fn describe_consumer_groups_batched(
     // borrowing from the caller's slice.
     let chunks: Vec<Vec<String>> = group_ids
         .chunks(chunk_size)
-        .map(|c| c.iter().map(|s| s.to_string()).collect())
+        .map(|c| c.iter().map(std::string::ToString::to_string).collect())
         .collect();
 
     // Each chunk carries enough identifying context to make partial-
@@ -363,7 +387,7 @@ pub async fn describe_consumer_groups_batched(
             let _permit: tokio::sync::OwnedSemaphorePermit =
                 permit.acquire_owned().await.expect("semaphore closed");
             let result = tokio::task::spawn_blocking(move || {
-                let refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
+                let refs: Vec<&str> = chunk.iter().map(std::string::String::as_str).collect();
                 describe_consumer_groups_one_chunk(&admin, &refs, timeout, parse_assignments)
             })
             .await;
@@ -535,7 +559,7 @@ fn describe_consumer_groups_one_chunk(
         }
 
         let mut n: usize = 0;
-        let groups_ptr = rd_kafka_DescribeConsumerGroups_result_groups(result, &mut n);
+        let groups_ptr = rd_kafka_DescribeConsumerGroups_result_groups(result, &raw mut n);
         let mut out = Vec::with_capacity(n);
         if groups_ptr.is_null() || n == 0 {
             return Ok(out);
@@ -781,7 +805,7 @@ fn list_consumer_group_offsets_one_chunk(
         }
 
         let mut n_groups: usize = 0;
-        let groups_ptr = rd_kafka_ListConsumerGroupOffsets_result_groups(result, &mut n_groups);
+        let groups_ptr = rd_kafka_ListConsumerGroupOffsets_result_groups(result, &raw mut n_groups);
         let mut out: HashMap<String, HashMap<TopicPartition, i64>> =
             HashMap::with_capacity(n_groups);
         if groups_ptr.is_null() || n_groups == 0 {

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -71,7 +71,7 @@ pub struct KafkaClient {
 }
 
 impl KafkaClient {
-    /// Create a new KafkaClient with default performance config.
+    /// Create a new `KafkaClient` with default performance config.
     /// Prefer `with_performance` for large clusters.
     #[allow(dead_code)]
     pub fn new(config: &ClusterConfig) -> Result<Self> {
@@ -94,7 +94,7 @@ impl KafkaClient {
         })
     }
 
-    /// Create fresh AdminClient + BaseConsumer pair.
+    /// Create fresh `AdminClient` + `BaseConsumer` pair.
     fn create_clients(
         config: &ClusterConfig,
     ) -> Result<(AdminClient<DefaultClientContext>, BaseConsumer)> {
@@ -129,10 +129,15 @@ impl KafkaClient {
 
     /// Get a snapshot of the current admin client (cheap Arc clone).
     fn admin(&self) -> Arc<AdminClient<DefaultClientContext>> {
-        Arc::clone(&self.admin.lock().unwrap_or_else(|p| p.into_inner()))
+        Arc::clone(
+            &self
+                .admin
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
     }
 
-    /// Public accessor for the underlying AdminClient Arc. Used by batched
+    /// Public accessor for the underlying `AdminClient` Arc. Used by batched
     /// Admin API wrappers in `kafka::admin` and by integration tests. The
     /// caller holds the Arc for the duration of the FFI call to keep the
     /// native handle valid.
@@ -142,7 +147,12 @@ impl KafkaClient {
 
     /// Get a snapshot of the current consumer (cheap Arc clone).
     fn consumer(&self) -> Arc<BaseConsumer> {
-        Arc::clone(&self.consumer.lock().unwrap_or_else(|p| p.into_inner()))
+        Arc::clone(
+            &self
+                .consumer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
     }
 
     /// Recycle internal Kafka clients to release accumulated librdkafka metadata.
@@ -154,22 +164,28 @@ impl KafkaClient {
         let rss_before = get_rss_kb();
         let (new_admin, new_consumer) = Self::create_clients(&self.config)?;
 
-        *self.admin.lock().unwrap_or_else(|p| p.into_inner()) = Arc::new(new_admin);
-        *self.consumer.lock().unwrap_or_else(|p| p.into_inner()) = Arc::new(new_consumer);
+        *self
+            .admin
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_admin);
+        *self
+            .consumer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_consumer);
 
         let rss_after = get_rss_kb();
         info!(
             cluster = %self.config.name,
             rss_before_kb = rss_before,
             rss_after_kb = rss_after,
-            rss_reclaimed_kb = rss_before as i64 - rss_after as i64,
+            rss_reclaimed_kb = rss_before.cast_signed() - rss_after.cast_signed(),
             "Recycled Kafka clients"
         );
         Ok(())
     }
 
     #[allow(dead_code)]
-    pub fn performance(&self) -> &PerformanceConfig {
+    pub const fn performance(&self) -> &PerformanceConfig {
         &self.performance
     }
 
@@ -258,7 +274,7 @@ impl KafkaClient {
     }
 
     /// Fetch low + high watermarks for an explicit partition set via batched
-    /// ListOffsets. Two Admin API calls total (EARLIEST + LATEST), regardless
+    /// `ListOffsets`. Two Admin API calls total (EARLIEST + LATEST), regardless
     /// of partition count. Replaces the prior per-partition `fetch_watermarks`
     /// fan-out (O(partitions) blocking calls via a semaphore).
     ///
@@ -286,16 +302,15 @@ impl KafkaClient {
             // flags `committed_offset < low_watermark`) while still surfacing
             // valid lag numbers. A 0 default would misrepresent the earliest
             // retained offset on compacted or retention-trimmed topics.
-            let low = match lows.get(&tp).copied() {
-                Some(l) => l,
-                None => {
-                    warn!(
-                        topic = %tp.topic,
-                        partition = tp.partition,
-                        "EARLIEST watermark missing; using LATEST as conservative fallback"
-                    );
-                    high
-                }
+            let low = if let Some(l) = lows.get(&tp).copied() {
+                l
+            } else {
+                warn!(
+                    topic = %tp.topic,
+                    partition = tp.partition,
+                    "EARLIEST watermark missing; using LATEST as conservative fallback"
+                );
+                high
             };
             merged.insert(tp, (low, high));
         }
@@ -374,13 +389,12 @@ impl KafkaClient {
 }
 
 /// Read current process RSS in kilobytes. Returns 0 on failure or non-Linux.
-/// Assumes 4 KB page size (standard for x86_64 Linux where /proc/self/statm exists).
+/// Assumes 4 KB page size (standard for `x86_64` Linux where /proc/self/statm exists).
 fn get_rss_kb() -> u64 {
     std::fs::read_to_string("/proc/self/statm")
         .ok()
         .and_then(|s| s.split_whitespace().nth(1)?.parse::<u64>().ok())
-        .map(|pages| pages * 4)
-        .unwrap_or(0)
+        .map_or(0, |pages| pages * 4)
 }
 
 impl std::fmt::Debug for KafkaClient {

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -17,7 +17,7 @@ pub struct TimestampFetchResult {
     pub timestamp_ms: i64,
 }
 
-/// Pool-based timestamp consumer. Maintains a pool of reusable BaseConsumers
+/// Pool-based timestamp consumer. Maintains a pool of reusable `BaseConsumers`
 /// to avoid connection churn (TCP/TLS/SASL handshake per fetch).
 pub struct TimestampConsumer {
     config: ClusterConfig,
@@ -91,13 +91,8 @@ impl TimestampConsumer {
         let mut pool = self
             .pool
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(consumer) = pool.pop() {
-            Ok(consumer)
-        } else {
-            // Pool exhausted (more concurrent fetches than pool_size); create a temporary one
-            self.create_consumer()
-        }
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        pool.pop().map_or_else(|| self.create_consumer(), Ok)
     }
 
     /// Return a consumer to the pool. If the pool is full, the consumer is dropped.
@@ -113,7 +108,7 @@ impl TimestampConsumer {
         let mut pool = self
             .pool
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if pool.len() < self.pool_size {
             pool.push(consumer);
         }
@@ -135,7 +130,7 @@ impl TimestampConsumer {
             consumer: Option<BaseConsumer>,
             pool: &'a TimestampConsumer,
         }
-        impl<'a> Drop for PoolGuard<'a> {
+        impl Drop for PoolGuard<'_> {
             fn drop(&mut self) {
                 if let Some(consumer) = self.consumer.take() {
                     self.pool.release(consumer);
@@ -155,8 +150,17 @@ impl TimestampConsumer {
 
         consumer.assign(&tpl).map_err(KlagError::Kafka)?;
 
-        let result = match consumer.poll(self.fetch_timeout) {
-            Some(result) => match result {
+        let result = consumer.poll(self.fetch_timeout).map_or_else(
+            || {
+                debug!(
+                    topic = %tp.topic,
+                    partition = tp.partition,
+                    offset = offset,
+                    "No message available at offset (may be beyond high watermark)"
+                );
+                Ok(None)
+            },
+            |result| match result {
                 Ok(msg) => {
                     let timestamp = msg.timestamp().to_millis();
 
@@ -181,17 +185,7 @@ impl TimestampConsumer {
                     Err(KlagError::Kafka(e))
                 }
             },
-            None => {
-                debug!(
-                    topic = %tp.topic,
-                    partition = tp.partition,
-                    offset = offset,
-                    "No message available at offset (may be beyond high watermark)"
-                );
-                Ok(None)
-            }
-        };
-
+        );
         // Take consumer out of guard so drop still returns it to pool
         // (guard.drop() handles the release)
         result
@@ -208,8 +202,9 @@ impl TimestampConsumer {
         let mut pool = self
             .pool
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         *pool = new_consumers;
+        drop(pool);
 
         debug!(
             cluster = %self.cluster_name,

--- a/src/leadership/mod.rs
+++ b/src/leadership/mod.rs
@@ -22,8 +22,8 @@ pub enum LeadershipState {
 }
 
 impl LeadershipState {
-    pub fn is_leader(&self) -> bool {
-        matches!(self, LeadershipState::Leader)
+    pub const fn is_leader(self) -> bool {
+        matches!(self, Self::Leader)
     }
 }
 

--- a/src/leadership/noop.rs
+++ b/src/leadership/noop.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 pub struct NoopLeader;
 
 impl NoopLeader {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,18 +142,17 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
         let leadership = leadership_status.clone();
 
         let handle = tokio::spawn(async move {
-            let manager =
-                match ClusterManager::new(cluster_config.clone(), registry, &exporter_config) {
-                    Ok(m) => m,
-                    Err(e) => {
-                        error!(
-                            cluster = cluster_config.name,
-                            error = %e,
-                            "Failed to create cluster manager"
-                        );
-                        return;
-                    }
-                };
+            let manager = match ClusterManager::new(&cluster_config, registry, &exporter_config) {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(
+                        cluster = cluster_config.name,
+                        error = %e,
+                        "Failed to create cluster manager"
+                    );
+                    return;
+                }
+            };
 
             manager.run(shutdown_rx, leadership).await;
         });
@@ -209,9 +208,10 @@ async fn async_main(config: Config) -> anyhow::Result<()> {
         futures::future::join_all(handles),
     );
 
-    match shutdown_timeout.await {
-        Ok(_) => info!("All cluster managers stopped"),
-        Err(_) => error!("Timeout waiting for cluster managers to stop"),
+    if shutdown_timeout.await.is_ok() {
+        info!("All cluster managers stopped");
+    } else {
+        error!("Timeout waiting for cluster managers to stop");
     }
 
     // Stop leadership provider
@@ -291,7 +291,7 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }

--- a/src/metrics/registry.rs
+++ b/src/metrics/registry.rs
@@ -18,6 +18,7 @@ use crate::metrics::definitions::{
 use crate::metrics::types::{Labels, MetricPoint, OtelDataPoint, OtelMetric};
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -54,20 +55,20 @@ impl MetricsRegistry {
 
     /// Update metrics with default options (partition granularity, no custom labels)
     #[allow(dead_code)]
-    pub fn update(&self, cluster: &str, lag_metrics: LagMetrics) {
+    pub fn update(&self, cluster: &str, lag_metrics: &LagMetrics) {
         self.update_with_options(
             cluster,
             lag_metrics,
             Granularity::Partition,
             &HashMap::new(),
-        )
+        );
     }
 
     /// Update metrics with granularity control and custom labels
     pub fn update_with_options(
         &self,
         cluster: &str,
-        lag_metrics: LagMetrics,
+        lag_metrics: &LagMetrics,
         granularity: Granularity,
         custom_labels: &HashMap<String, String>,
     ) {
@@ -218,7 +219,7 @@ impl MetricsRegistry {
             points.push(MetricPoint::gauge(
                 METRIC_GROUP_STATE,
                 labels,
-                m.state as f64,
+                f64::from(m.state),
                 HELP_GROUP_STATE,
             ));
         }
@@ -296,11 +297,11 @@ impl MetricsRegistry {
         self.last_scrape_duration_ms.load(Ordering::SeqCst) as f64 / 1000.0
     }
 
-    /// Check if any cluster's data is stale (older than staleness_threshold)
+    /// Check if any cluster's data is stale (older than `staleness_threshold`)
     #[allow(dead_code)]
     pub fn is_data_stale(&self) -> bool {
         let now = Instant::now();
-        for entry in self.last_update.iter() {
+        for entry in &self.last_update {
             if now.duration_since(*entry.value()) > self.staleness_threshold {
                 return true;
             }
@@ -337,11 +338,11 @@ impl MetricsRegistry {
                     return true;
                 }
                 // Check if this cluster's data is fresh
-                if let Some(last_update) = self.last_update.get(entry.key()) {
-                    now.duration_since(*last_update) <= self.staleness_threshold
-                } else {
-                    false // No timestamp means stale
-                }
+                self.last_update
+                    .get(entry.key())
+                    .is_some_and(|last_update| {
+                        now.duration_since(*last_update) <= self.staleness_threshold
+                    })
             })
             .flat_map(|entry| entry.value().clone())
             .collect();
@@ -365,55 +366,48 @@ impl MetricsRegistry {
             // Output HELP and TYPE once per metric
             if !seen_metrics.contains(&name) {
                 let first = &points[0];
-                output.push_str(&format!("# HELP {} {}\n", name, first.help));
-                output.push_str(&format!("# TYPE {} {}\n", name, first.metric_type.as_str()));
+                let _ = writeln!(output, "# HELP {} {}", name, first.help);
+                let _ = writeln!(output, "# TYPE {} {}", name, first.metric_type.as_str());
                 seen_metrics.insert(name.clone());
             }
 
             // Output all data points
             for point in points {
-                let labels_str = render_labels(&point.labels);
-                output.push_str(&format!(
-                    "{}{} {}\n",
+                let _ = writeln!(
+                    output,
+                    "{}{} {}",
                     point.name,
-                    labels_str,
+                    render_labels(&point.labels),
                     point.value.as_f64()
-                ));
+                );
             }
         }
 
         // Add scrape duration metric
         let scrape_duration = self.get_scrape_duration_seconds();
-        output.push_str(&format!(
-            "# HELP {} {}\n",
-            METRIC_SCRAPE_DURATION_SECONDS, HELP_SCRAPE_DURATION_SECONDS
-        ));
-        output.push_str(&format!(
-            "# TYPE {} gauge\n",
-            METRIC_SCRAPE_DURATION_SECONDS
-        ));
-        output.push_str(&format!(
-            "{} {:.6}\n",
-            METRIC_SCRAPE_DURATION_SECONDS, scrape_duration
-        ));
+        let _ = writeln!(
+            output,
+            "# HELP {METRIC_SCRAPE_DURATION_SECONDS} {HELP_SCRAPE_DURATION_SECONDS}"
+        );
+        let _ = writeln!(output, "# TYPE {METRIC_SCRAPE_DURATION_SECONDS} gauge");
+        let _ = writeln!(
+            output,
+            "{METRIC_SCRAPE_DURATION_SECONDS} {scrape_duration:.6}"
+        );
 
         // Add exporter health metric
-        output.push_str(&format!("# HELP {} {}\n", METRIC_UP, HELP_UP));
-        output.push_str(&format!("# TYPE {} gauge\n", METRIC_UP));
-        output.push_str(&format!(
-            "{} {}\n",
-            METRIC_UP,
-            if self.is_healthy() { 1 } else { 0 }
-        ));
+        let _ = writeln!(output, "# HELP {METRIC_UP} {HELP_UP}");
+        let _ = writeln!(output, "# TYPE {METRIC_UP} gauge");
+        let _ = writeln!(output, "{} {}", METRIC_UP, i32::from(self.is_healthy()));
 
         // Add last update timestamp metric per cluster
         if !self.last_update_timestamp.is_empty() {
-            output.push_str(&format!(
-                "# HELP {} {}\n",
-                METRIC_LAST_UPDATE_TIMESTAMP, HELP_LAST_UPDATE_TIMESTAMP
-            ));
-            output.push_str(&format!("# TYPE {} gauge\n", METRIC_LAST_UPDATE_TIMESTAMP));
-            for entry in self.last_update_timestamp.iter() {
+            let _ = writeln!(
+                output,
+                "# HELP {METRIC_LAST_UPDATE_TIMESTAMP} {HELP_LAST_UPDATE_TIMESTAMP}"
+            );
+            let _ = writeln!(output, "# TYPE {METRIC_LAST_UPDATE_TIMESTAMP} gauge");
+            for entry in &self.last_update_timestamp {
                 let cluster = entry.key();
                 let timestamp = entry.value();
                 // Only include non-stale clusters if filtering is enabled
@@ -424,10 +418,10 @@ impl MetricsRegistry {
                         }
                     }
                 }
-                output.push_str(&format!(
-                    "{}{{{}=\"{}\"}} {}\n",
-                    METRIC_LAST_UPDATE_TIMESTAMP, LABEL_CLUSTER_NAME, cluster, timestamp
-                ));
+                let _ = writeln!(
+                    output,
+                    "{METRIC_LAST_UPDATE_TIMESTAMP}{{{LABEL_CLUSTER_NAME}=\"{cluster}\"}} {timestamp}"
+                );
             }
         }
 
@@ -438,10 +432,10 @@ impl MetricsRegistry {
         let mut otel_metrics: HashMap<String, OtelMetric> = HashMap::new();
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
+            .unwrap_or_default()
+            .as_millis();
 
-        for entry in self.metrics.iter() {
+        for entry in &self.metrics {
             for point in entry.value() {
                 let metric = otel_metrics
                     .entry(point.name.clone())
@@ -519,7 +513,7 @@ fn render_labels(labels: &Labels) -> String {
         .collect::<Vec<_>>()
         .join(",");
 
-    format!("{{{}}}", label_str)
+    format!("{{{label_str}}}")
 }
 
 fn escape_label_value(value: &str) -> String {
@@ -594,7 +588,7 @@ mod tests {
         let registry = MetricsRegistry::new();
 
         let metrics1 = make_lag_metrics();
-        registry.update("test-cluster", metrics1);
+        registry.update("test-cluster", &metrics1);
 
         let output1 = registry.render_prometheus();
         assert!(output1.contains("kafka_consumergroup_group_lag"));
@@ -602,7 +596,7 @@ mod tests {
         // Update with new metrics
         let mut metrics2 = make_lag_metrics();
         metrics2.partition_metrics[0].lag = 20;
-        registry.update("test-cluster", metrics2);
+        registry.update("test-cluster", &metrics2);
 
         let output2 = registry.render_prometheus();
         assert!(output2.contains("20")); // New lag value
@@ -612,7 +606,7 @@ mod tests {
     fn test_prometheus_format_gauge() {
         let registry = MetricsRegistry::new();
         let metrics = make_lag_metrics();
-        registry.update("test-cluster", metrics);
+        registry.update("test-cluster", &metrics);
 
         let output = registry.render_prometheus();
 
@@ -626,7 +620,7 @@ mod tests {
     fn test_prometheus_format_labels() {
         let registry = MetricsRegistry::new();
         let metrics = make_lag_metrics();
-        registry.update("test-cluster", metrics);
+        registry.update("test-cluster", &metrics);
 
         let output = registry.render_prometheus();
 
@@ -648,7 +642,7 @@ mod tests {
         let registry = MetricsRegistry::new();
 
         let metrics = make_lag_metrics();
-        registry.update("cluster1", metrics);
+        registry.update("cluster1", &metrics);
 
         assert_eq!(registry.cluster_count(), 1);
 
@@ -684,7 +678,12 @@ mod tests {
         let registry = MetricsRegistry::new();
         let metrics = make_lag_metrics();
 
-        registry.update_with_options("test-cluster", metrics, Granularity::Topic, &HashMap::new());
+        registry.update_with_options(
+            "test-cluster",
+            &metrics,
+            Granularity::Topic,
+            &HashMap::new(),
+        );
 
         let output = registry.render_prometheus();
 
@@ -708,7 +707,7 @@ mod tests {
 
         registry.update_with_options(
             "test-cluster",
-            metrics,
+            &metrics,
             Granularity::Partition,
             &custom_labels,
         );

--- a/src/metrics/types.rs
+++ b/src/metrics/types.rs
@@ -7,10 +7,9 @@ pub enum MetricValue {
 }
 
 impl MetricValue {
-    pub fn as_f64(&self) -> f64 {
+    pub const fn as_f64(&self) -> f64 {
         match self {
-            MetricValue::Gauge(v) => *v,
-            MetricValue::Counter(v) => *v,
+            Self::Gauge(v) | Self::Counter(v) => *v,
         }
     }
 }
@@ -33,10 +32,10 @@ pub enum MetricType {
 }
 
 impl MetricType {
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
-            MetricType::Gauge => "gauge",
-            MetricType::Counter => "counter",
+            Self::Gauge => "gauge",
+            Self::Counter => "counter",
         }
     }
 }
@@ -84,5 +83,5 @@ pub struct OtelDataPoint {
     pub attributes: HashMap<String, String>,
     pub value: f64,
     #[allow(dead_code)]
-    pub timestamp_ms: i64,
+    pub timestamp_ms: u128,
 }


### PR DESCRIPTION
- **fix missing compression libs**
- **chore: release v0.1.16**
- **chore(helm): update chart and image versions to 0.1.16**
- **feat: add kafka_consumergroup_group_state metric**
- **style: fix cargo fmt formatting**
- **chore: release v0.1.17**
- **chore(helm): update chart and image versions to 0.1.17**
- **updated the docs with new metric info**
- **chore: release v0.1.17**
- **chore(helm): update chart and image versions to 0.1.17**
- **chore: release v0.1.18**
- **chore(helm): update chart and image versions to 0.1.18**
- **Fix native FFI memory leak and improve memory management**
- **chore: release v0.1.19**
- **chore(helm): update chart and image versions to 0.1.19**
- **Support the new config option in helm chart**
- **Update helm/klag-exporter/templates/configmap.yaml**
- **Update helm/klag-exporter/values.yaml**
- **Update helm/klag-exporter/templates/configmap.yaml**
- **chore: release v0.1.20**
- **chore(helm): update chart and image versions to 0.1.20**
- **fix(grafana): widen Topic Message Rate window to [5m]**
- **feat(kafka): scaffold admin module for batched Admin API wrappers**
- **feat(kafka): add batched list_offsets_batched FFI wrapper**
- **feat(kafka): expose admin_handle for batched Admin API callers**
- **feat(kafka): add batched describe_consumer_groups_batched FFI wrapper**
- **feat(kafka): add batched list_consumer_group_offsets_batched FFI wrapper**
- **perf(kafka): replace sequential describe_consumer_groups with batched Admin API**
- **feat(kafka): add fetch_watermarks_for_partitions using batched ListOffsets**
- **perf(collector): rewire hot path to batched Admin API with pre-filtered topics**
- **refactor(kafka): remove legacy per-partition watermark + single-group offset FFI**
- **docs(readme): describe batched Admin API collection model and updated sizing guidance**
- **chore(docker): bump Dockerfile.dev rust image to 1.92**
- **review: address Copilot PR feedback (Tier 1)**
- **chore: release v0.1.21**
- **chore(helm): update chart and image versions to 0.1.21**
- **perf(runtime): cap tokio blocking-thread pool (default 64)**
- **perf(kafka): skip member-assignment parsing unless granularity=partition**
- **perf(collector): add TTL cache for compacted-topic detection**
- **perf(collector): add TTL cache for filtered monitored-topic set**
- **perf(kafka): intern topic names as Arc<str> with per-call dedup**
- **review: address Copilot PR feedback (Tier 2)**
- **feat(collector): add RateSampler for rate-based time-lag estimation**
- **feat: switch time-lag default to rate-based estimation (Tier 3)**
- **docs(readme): document rate vs message time-lag modes**
- **review: address Copilot PR feedback (Tier 3)**
- **perf(kafka): parallelize DescribeConsumerGroups chunks**
- **perf(collector): TTL cache list_consumer_groups (default 60s)**
- **obs(collector): per-phase elapsed_ms in the cycle-complete debug log**
- **deprecate: max_concurrent_watermarks (no-op since Tier 1 batched ListOffsets)**
- **review: address Copilot PR feedback (Tier 4)**
- **chore: release v0.1.22**
- **chore(helm): update chart and image versions to 0.1.22**
- **docs: document timestamp_sampling.mode in test-stack + config example**
- **review: address Copilot feedback on PR #72**
- **chore: release v0.1.22**
- **Support the new 'mode' config options in helm chart**
- **feat: configurable metrics staleness threshold (#60)**
- **review: validate poll_interval > 0 and staleness_threshold > 0**
- **feat(helm): expose exporter.staleness_threshold**
- **docs: document exporter.staleness_threshold in README**
- **Update helm/klag-exporter/templates/configmap.yaml**
- **chore: release v0.1.23**
- **chore(helm): update chart and image versions to 0.1.23**
- **helm: Fix typos and add configuration stub**
- **fix(helm): derive containerPort from config.exporter.http_port**
- **chore: release v0.1.24**
- **chore(helm): update chart and image versions to 0.1.24**
- **devex: add nix tooling for reproducible builds**
- **upkeep(clippy): clean up 100+ clippy lints**
