### PR TITLE
feat(helm): add serviceMonitor.additionalLabels

### DIFF
--- a/helm/klag-exporter/templates/servicemonitor.yaml
+++ b/helm/klag-exporter/templates/servicemonitor.yaml
@@ -4,10 +4,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "klag-exporter.fullname" . }}
   labels:
-    {{- include "klag-exporter.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- $baseLabels := include "klag-exporter.labels" . | fromYaml }}
+    {{- $extraLabels := .Values.serviceMonitor.additionalLabels | default dict }}
+    {{- toYaml (merge $baseLabels $extraLabels) | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/helm/klag-exporter/templates/servicemonitor.yaml
+++ b/helm/klag-exporter/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "klag-exporter.fullname" . }}
   labels:
     {{- include "klag-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -235,6 +235,8 @@ affinity: {}
 
 serviceMonitor:
   enabled: false
+  # Additional labels for the serviceMonitor metadata
+  additionalLabels: {}
   # Additional config for endpoint
   additionalEndpointConfig: {}
   # Additional config for serviceMonitor spec


### PR DESCRIPTION
Lets the ServiceMonitor carry extra metadata labels. Needed where a Prometheus discovers ServiceMonitors via a serviceMonitorSelector (e.g. kube-prometheus-stack's default match on `release: <release-name>`), which the chart previously couldn't satisfy.