### PR TITLE
chore: align remaining Rust pins at 1.96

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -34,7 +34,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config libcurl4-openssl-dev
-      - uses: dtolnay/rust-toolchain@1.93
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           components: clippy
       - name: Rust version
@@ -58,7 +58,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config libcurl4-openssl-dev
-      - uses: dtolnay/rust-toolchain@1.93
+      - uses: dtolnay/rust-toolchain@1.96
       - name: Rust version
         id: rust_version
         run: echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
@@ -80,7 +80,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update
           sudo apt-get install -y cmake build-essential libssl-dev libsasl2-dev zlib1g-dev libzstd-dev liblz4-dev pkg-config libcurl4-openssl-dev
-      - uses: dtolnay/rust-toolchain@1.93
+      - uses: dtolnay/rust-toolchain@1.96
       - name: Rust version
         id: rust_version
         run: echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         inherit (pkgs) lib;
         cargoToml = lib.fromTOML (lib.readFile ./Cargo.toml);
 
-        rustToolchain = pkgs.rust-bin.stable."1.93.0".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.96.0".default.override {
           extensions = [
             "clippy"
             "rust-analyzer"


### PR DESCRIPTION
#93 bumped the release workflows and `Dockerfile.dev` to Rust 1.96, but `ci.yml` still installs 1.93 and the nix flake pins 1.93.0. Align both so CI, release builds and nix builds all use the same toolchain.

The locked rust-overlay snapshot ships 1.96.0, so the flake pin resolves without a `flake.lock` update. Verified locally on 1.96.1: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all-features` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)