### PR TITLE
feat: configurable message-mode fetch timeout (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ rate_min_msgs_per_sec = 0.01       # below this rate → time lag reported as mi
 # Message-mode tuning (only used when mode = "message"):
 cache_ttl = "60s"
 max_concurrent_fetches = 10
+fetch_timeout = "5s"
 
 [exporter.otel]
 enabled = false
@@ -642,6 +643,13 @@ Each entry in the timestamp consumer pool (`max_concurrent_fetches`) is a full l
 ```toml
 [exporter.timestamp_sampling]
 max_concurrent_fetches = 5   # Default: 5. Each is a full Kafka client.
+```
+
+Each fetch polls for a message at the committed offset for up to `fetch_timeout` (default 5s) before giving up. On idle or largely idle clusters many committed offsets sit at the partition's high watermark with no message to read, so every one of those fetches blocks for the full timeout; on large clusters that serializes behind `max_concurrent_fetches` and can push a collection cycle past the poll interval. Lower it to bound the worst-case per-fetch wait:
+
+```toml
+[exporter.timestamp_sampling]
+fetch_timeout = "5s"   # Default: 5s. Per-message poll timeout.
 ```
 
 ## Troubleshooting

--- a/config.example.toml
+++ b/config.example.toml
@@ -36,6 +36,10 @@ enabled = true
 # Message-mode settings (ignored when mode = "rate"):
 cache_ttl = "60s"
 max_concurrent_fetches = 5
+# Per-message poll timeout: how long each fetch waits for a message at the
+# committed offset before giving up. Bounds the per-fetch wait so an idle
+# partition or slow broker can't stall the collection cycle.
+fetch_timeout = "5s"
 
 # Rate-mode settings (ignored when mode = "message"):
 # rate_history_samples = 5       # watermark observations per partition

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
     {{- if .max_concurrent_fetches }}
     max_concurrent_fetches = {{ .max_concurrent_fetches }}
     {{- end }}
+    {{- if .fetch_timeout }}
+    fetch_timeout = {{ .fetch_timeout | quote }}
+    {{- end }}
     {{- if .rate_history_samples }}
     rate_history_samples = {{ .rate_history_samples }}
     {{- end }}

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -139,6 +139,7 @@ config:
     # Message-mode settings (ignored when mode = "rate"):
     # cache_ttl: "60s"
     # max_concurrent_fetches: 10
+    # fetch_timeout: "5s"
     # Rate-mode settings (ignored when mode = "message"):
     # rate_history_samples: 5
     # rate_history_max_age: "10m"

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -58,8 +58,11 @@ impl ClusterManager {
                     // Only build the pool when actually using it. This is
                     // the Tier-3 resident-memory saving for rate-mode users:
                     // no BaseConsumer pool, no extra librdkafka clients.
-                    let ts_consumer =
-                        TimestampConsumer::with_pool_size(config, ts_cfg.max_concurrent_fetches)?;
+                    let ts_consumer = TimestampConsumer::with_pool_size(
+                        config,
+                        ts_cfg.max_concurrent_fetches,
+                        ts_cfg.fetch_timeout,
+                    )?;
                     TimestampSampler::new_message(ts_consumer, ts_cfg.cache_ttl)
                 }
                 crate::config::TimestampSamplingMode::Rate => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,12 @@ pub struct TimestampSamplingConfig {
     /// `rate` mode (rate mode does no I/O).
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: usize,
+    /// `message` mode: how long each per-message poll waits for a message at
+    /// the committed offset before giving up. Bounds the per-fetch wait so an
+    /// idle partition (no message at the offset) or a slow broker doesn't
+    /// stall the collection cycle. Ignored in `rate` mode.
+    #[serde(with = "humantime_serde", default = "default_fetch_timeout")]
+    pub fetch_timeout: Duration,
     /// `rate` mode: maximum number of (time, `high_watermark`) samples
     /// retained per partition. Larger = smoother rate estimate, more
     /// memory. Default 5.
@@ -256,6 +262,10 @@ const fn default_max_concurrent_fetches() -> usize {
     5
 }
 
+const fn default_fetch_timeout() -> Duration {
+    Duration::from_secs(5)
+}
+
 const fn default_timestamp_sampling_mode() -> TimestampSamplingMode {
     TimestampSamplingMode::Rate
 }
@@ -351,6 +361,7 @@ impl Default for TimestampSamplingConfig {
             mode: default_timestamp_sampling_mode(),
             cache_ttl: default_cache_ttl(),
             max_concurrent_fetches: default_max_concurrent_fetches(),
+            fetch_timeout: default_fetch_timeout(),
             rate_history_samples: default_rate_history_samples(),
             rate_history_max_age: default_rate_history_max_age(),
             rate_min_msgs_per_sec: default_rate_min_msgs_per_sec(),
@@ -481,6 +492,28 @@ impl Config {
                 "timestamp_sampling.max_concurrent_fetches must be >= 1 when mode = 'message'"
                     .to_string(),
             ));
+        }
+        if ts.enabled && ts.mode == TimestampSamplingMode::Message {
+            // A zero per-fetch timeout makes librdkafka's poll non-blocking, so
+            // it returns before the just-assigned partition's fetch completes
+            // and no timestamp is ever sampled. librdkafka's poll timeout is an
+            // i32 count of milliseconds; a value that overflows that field wraps
+            // to a negative number, which librdkafka treats as "block forever" —
+            // the opposite of bounding the per-fetch wait. Keep the timeout in
+            // the (0, i32::MAX ms] range so it always maps to a finite wait.
+            if ts.fetch_timeout.is_zero() {
+                return Err(KlagError::Config(
+                    "timestamp_sampling.fetch_timeout must be greater than 0 when mode = 'message'"
+                        .to_string(),
+                ));
+            }
+            if ts.fetch_timeout.as_millis() > i32::MAX as u128 {
+                return Err(KlagError::Config(format!(
+                    "timestamp_sampling.fetch_timeout ({:?}) must not exceed {} ms (~24.8 days)",
+                    ts.fetch_timeout,
+                    i32::MAX
+                )));
+            }
         }
         if ts.enabled && ts.mode == TimestampSamplingMode::Rate {
             if ts.rate_history_samples < 2 {
@@ -789,6 +822,10 @@ bootstrap_servers = "localhost:9092"
             TimestampSamplingMode::Rate,
             "default mode should be rate (Tier 3)"
         );
+        assert_eq!(
+            config.exporter.timestamp_sampling.fetch_timeout,
+            Duration::from_secs(5)
+        );
         assert!(!config.exporter.otel.enabled);
         // Performance defaults
         assert_eq!(
@@ -974,6 +1011,118 @@ bootstrap_servers = "localhost:9092"
             err.to_string()
                 .contains("max_concurrent_fetches must be >= 1"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_timeout_parses_and_defaults() {
+        // Omitted → default 5s.
+        let default_content = r#"
+[exporter]
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(default_content.as_bytes()).unwrap();
+        let config = Config::load(Some(file.path().to_str().unwrap())).unwrap();
+        assert_eq!(
+            config.exporter.timestamp_sampling.fetch_timeout,
+            Duration::from_secs(5),
+            "fetch_timeout should default to 5s when omitted"
+        );
+
+        // Set explicitly → parsed from the humantime string.
+        let custom_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+fetch_timeout = "12s"
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(custom_content.as_bytes()).unwrap();
+        let config = Config::load(Some(file.path().to_str().unwrap())).unwrap();
+        assert_eq!(
+            config.exporter.timestamp_sampling.fetch_timeout,
+            Duration::from_secs(12)
+        );
+    }
+
+    #[test]
+    fn test_message_mode_rejects_zero_fetch_timeout() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+fetch_timeout = "0s"
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("fetch_timeout must be greater than 0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_message_mode_rejects_overflowing_fetch_timeout() {
+        // 30 days > i32::MAX ms (~24.8 days) → would wrap negative in librdkafka.
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+fetch_timeout = "30days"
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string().contains("fetch_timeout")
+                && err.to_string().contains("must not exceed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rate_mode_ignores_zero_fetch_timeout() {
+        // fetch_timeout is a message-mode knob; in rate mode a zero value must
+        // not be rejected (the sampler never reads it).
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "rate"
+fetch_timeout = "0s"
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let config = Config::load(Some(file.path().to_str().unwrap()))
+            .expect("rate mode should ignore fetch_timeout");
+        assert_eq!(
+            config.exporter.timestamp_sampling.fetch_timeout,
+            Duration::ZERO
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -494,20 +494,22 @@ impl Config {
             ));
         }
         if ts.enabled && ts.mode == TimestampSamplingMode::Message {
-            // A zero per-fetch timeout makes librdkafka's poll non-blocking, so
-            // it returns before the just-assigned partition's fetch completes
-            // and no timestamp is ever sampled. librdkafka's poll timeout is an
-            // i32 count of milliseconds; a value that overflows that field wraps
-            // to a negative number, which librdkafka treats as "block forever" —
-            // the opposite of bounding the per-fetch wait. Keep the timeout in
-            // the (0, i32::MAX ms] range so it always maps to a finite wait.
-            if ts.fetch_timeout.is_zero() {
-                return Err(KlagError::Config(
-                    "timestamp_sampling.fetch_timeout must be greater than 0 when mode = 'message'"
-                        .to_string(),
-                ));
+            // librdkafka's poll timeout is an i32 count of milliseconds. A value
+            // that rounds down to 0ms makes poll non-blocking, so it returns
+            // before the just-assigned partition's fetch completes and no
+            // timestamp is ever sampled; a value that overflows i32 wraps to a
+            // negative number, which librdkafka treats as "block forever" — the
+            // opposite of bounding the per-fetch wait. Validate the millisecond
+            // value directly (not Duration::is_zero) so a sub-millisecond timeout
+            // like "500us", which truncates to 0ms, is also rejected.
+            let timeout_ms = ts.fetch_timeout.as_millis();
+            if timeout_ms == 0 {
+                return Err(KlagError::Config(format!(
+                    "timestamp_sampling.fetch_timeout ({:?}) must be at least 1ms when mode = 'message'",
+                    ts.fetch_timeout
+                )));
             }
-            if ts.fetch_timeout.as_millis() > i32::MAX as u128 {
+            if timeout_ms > i32::MAX as u128 {
                 return Err(KlagError::Config(format!(
                     "timestamp_sampling.fetch_timeout ({:?}) must not exceed {} ms (~24.8 days)",
                     ts.fetch_timeout,
@@ -1071,8 +1073,31 @@ bootstrap_servers = "localhost:9092"
         file.write_all(config_content.as_bytes()).unwrap();
         let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("fetch_timeout must be greater than 0"),
+            err.to_string().contains("must be at least 1ms"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_message_mode_rejects_submillisecond_fetch_timeout() {
+        // 500us is non-zero but truncates to 0ms for librdkafka's poll — the
+        // same non-blocking failure as 0s, so it must be rejected too.
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+fetch_timeout = "500us"
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let err = Config::load(Some(file.path().to_str().unwrap())).unwrap_err();
+        assert!(
+            err.to_string().contains("must be at least 1ms"),
             "unexpected error: {err}"
         );
     }

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -29,11 +29,15 @@ pub struct TimestampConsumer {
 }
 
 impl TimestampConsumer {
-    pub fn with_pool_size(config: &ClusterConfig, pool_size: usize) -> Result<Self> {
+    pub fn with_pool_size(
+        config: &ClusterConfig,
+        pool_size: usize,
+        fetch_timeout: Duration,
+    ) -> Result<Self> {
         let mut consumer = Self {
             config: config.clone(),
             cluster_name: config.name.clone(),
-            fetch_timeout: Duration::from_secs(5),
+            fetch_timeout,
             consumer_counter: AtomicU64::new(0),
             pool: Mutex::new(Vec::with_capacity(pool_size)),
             pool_size,


### PR DESCRIPTION
## Summary
- Makes the message-mode per-message poll timeout configurable via
  `exporter.timestamp_sampling.fetch_timeout` (humantime `Duration`).
- Previously hardcoded to 5s; default stays `5s`, so behaviour is unchanged
  when the knob is unset.
- Surfaced as a Helm chart value.

Addresses the `fetch_timeout` ask in #94. Does **not** close #94 — the
retention-unavailable skip ask from the same issue is a separate PR.

## Background
In message mode, each timestamp fetch polls for the message at the committed
offset for up to the fetch timeout before giving up. On idle or largely-idle
clusters, many committed offsets sit at the partition high watermark with no
message to read, so every such fetch blocks for the full timeout; behind
`max_concurrent_fetches` that serializes and can push a collection cycle past
the poll interval. A fixed 5s left no way to bound the worst-case per-fetch
wait without a code change.

## Changes
- `src/config.rs` — new `timestamp_sampling.fetch_timeout: Duration`
  (default `5s`). Validated in message mode to fall within librdkafka's
  `(0, i32::MAX ms]` poll range — rejects `0s` and values that overflow to a
  negative millisecond count. Rate mode ignores it.
- Plumbed through to the `TimestampConsumer` pool.
- `helm/klag-exporter/{values.yaml,templates/configmap.yaml}` — rendered when set.
- `README.md`, `config.example.toml` — documented.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — green, incl. new tests: default, explicit
      parse, message-mode rejects `0s`, message-mode rejects overflow
      (`30days`), rate-mode ignores `0s`
- [x] `cargo build --release` — clean
- [x] `helm lint` + `helm template` — clean
