### PR TITLE
feat: skip message fetch for data-loss partitions (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ rate_min_msgs_per_sec = 0.01       # below this rate → time lag reported as mi
 cache_ttl = "60s"
 max_concurrent_fetches = 10
 # Skip the fetch for partitions whose committed offset is below the low
-# watermark (retention deleted the committed message). Offset lag stays exact
-# and time lag is reported as 0 with data_loss_detected. Default false.
+# watermark (retention deleted the committed message). Offset lag and time lag
+# are both reported as 0 with data_loss_detected (magnitude in messages_lost /
+# retention_margin). Default false.
 skip_data_loss_partitions = false
 
 [exporter.otel]

--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ rate_min_msgs_per_sec = 0.01       # below this rate → time lag reported as mi
 # Message-mode tuning (only used when mode = "message"):
 cache_ttl = "60s"
 max_concurrent_fetches = 10
+# Skip the fetch for partitions whose committed offset is below the low
+# watermark (retention deleted the committed message). Offset lag stays exact
+# and time lag is reported as 0 with data_loss_detected. Default false.
+skip_data_loss_partitions = false
 
 [exporter.otel]
 enabled = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -36,6 +36,11 @@ enabled = true
 # Message-mode settings (ignored when mode = "rate"):
 cache_ttl = "60s"
 max_concurrent_fetches = 5
+# Skip the per-message fetch for partitions whose committed offset is below the
+# low watermark (retention deleted the committed message). Such a fetch can only
+# time out or read the wrong earliest message; offset lag stays exact and time
+# lag is reported as 0 with data_loss_detected. Default false.
+skip_data_loss_partitions = false
 
 # Rate-mode settings (ignored when mode = "message"):
 # rate_history_samples = 5       # watermark observations per partition

--- a/config.example.toml
+++ b/config.example.toml
@@ -38,8 +38,9 @@ cache_ttl = "60s"
 max_concurrent_fetches = 5
 # Skip the per-message fetch for partitions whose committed offset is below the
 # low watermark (retention deleted the committed message). Such a fetch can only
-# time out or read the wrong earliest message; offset lag stays exact and time
-# lag is reported as 0 with data_loss_detected. Default false.
+# time out or read the wrong earliest message; offset lag and time lag are both
+# reported as 0 with data_loss_detected (magnitude in messages_lost /
+# retention_margin). Default false.
 skip_data_loss_partitions = false
 
 # Rate-mode settings (ignored when mode = "message"):

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
     {{- if .max_concurrent_fetches }}
     max_concurrent_fetches = {{ .max_concurrent_fetches }}
     {{- end }}
+    {{- if .skip_data_loss_partitions }}
+    skip_data_loss_partitions = {{ .skip_data_loss_partitions }}
+    {{- end }}
     {{- if .rate_history_samples }}
     rate_history_samples = {{ .rate_history_samples }}
     {{- end }}

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
     {{- if .max_concurrent_fetches }}
     max_concurrent_fetches = {{ .max_concurrent_fetches }}
     {{- end }}
-    {{- if .skip_data_loss_partitions }}
+    {{- if hasKey . "skip_data_loss_partitions" }}
     skip_data_loss_partitions = {{ .skip_data_loss_partitions }}
     {{- end }}
     {{- if .rate_history_samples }}

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -139,6 +139,10 @@ config:
     # Message-mode settings (ignored when mode = "rate"):
     # cache_ttl: "60s"
     # max_concurrent_fetches: 10
+    # Skip the fetch for partitions whose committed offset is below the low
+    # watermark (retention deleted the committed message); offset lag stays
+    # exact and time lag is reported as 0 with data_loss_detected. Default false.
+    # skip_data_loss_partitions: true
     # Rate-mode settings (ignored when mode = "message"):
     # rate_history_samples: 5
     # rate_history_max_age: "10m"

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -140,8 +140,9 @@ config:
     # cache_ttl: "60s"
     # max_concurrent_fetches: 10
     # Skip the fetch for partitions whose committed offset is below the low
-    # watermark (retention deleted the committed message); offset lag stays
-    # exact and time lag is reported as 0 with data_loss_detected. Default false.
+    # watermark (retention deleted the committed message); offset lag and time
+    # lag are both reported as 0 with data_loss_detected (magnitude in
+    # messages_lost / retention_margin). Default false.
     # skip_data_loss_partitions: true
     # Rate-mode settings (ignored when mode = "message"):
     # rate_history_samples: 5

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -27,6 +27,7 @@ pub struct ClusterManager {
     max_backoff: Duration,
     granularity: Granularity,
     max_concurrent_fetches: usize,
+    skip_data_loss_partitions: bool,
     cache_cleanup_interval: Duration,
     collection_timeout: Duration,
     client_recycle_interval: u64,
@@ -104,6 +105,7 @@ impl ClusterManager {
             max_backoff: Duration::from_mins(5),
             granularity: exporter_config.granularity,
             max_concurrent_fetches: exporter_config.timestamp_sampling.max_concurrent_fetches,
+            skip_data_loss_partitions: exporter_config.timestamp_sampling.skip_data_loss_partitions,
             cache_cleanup_interval: exporter_config.timestamp_sampling.cache_ttl * 2,
             collection_timeout,
             client_recycle_interval: exporter_config.performance.client_recycle_interval,
@@ -290,7 +292,12 @@ impl ClusterManager {
         // configured (rate = no I/O, message = bounded concurrent FFI).
         let timestamps = if let Some(ref sampler) = self.timestamp_sampler {
             sampler
-                .compute_time_lags(&snapshot, now_ms, self.max_concurrent_fetches)
+                .compute_time_lags(
+                    &snapshot,
+                    now_ms,
+                    self.max_concurrent_fetches,
+                    self.skip_data_loss_partitions,
+                )
                 .await
         } else {
             HashMap::new()

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -142,11 +142,16 @@ impl LagCalculator {
                     snapshot.get_watermark(tp).unwrap_or((0, *committed_offset));
 
                 // Calculate lag, clamped to 0 for race conditions
-                let lag = (high_watermark - committed_offset).max(0);
+                let raw_lag = (high_watermark - committed_offset).max(0);
 
                 // Data loss detection: committed offset is before the low watermark
                 let data_loss_detected = *committed_offset < low_watermark;
                 let messages_lost = (low_watermark - *committed_offset).max(0);
+
+                // On data loss the committed offset is below the low watermark, so the
+                // gap is unconsumable; report 0 offset lag. messages_lost and
+                // retention_margin carry the magnitude.
+                let lag = if data_loss_detected { 0 } else { raw_lag };
 
                 // Prevention metrics
                 let retention_margin = *committed_offset - low_watermark; // negative if data loss
@@ -175,7 +180,7 @@ impl LagCalculator {
                 let ts_data = timestamps.get(&(group.group_id.clone(), tp.clone()));
                 let lag_seconds = if !time_lag_enabled {
                     None
-                } else if lag > 0 {
+                } else if raw_lag > 0 {
                     ts_data
                         .map(|td| ((now_ms - td.timestamp_ms) as f64) / 1000.0)
                         .map(|s| s.max(0.0))
@@ -413,9 +418,10 @@ mod tests {
     fn data_loss_partition_without_timestamp_emits_zero_seconds() {
         // A partition whose committed offset is below the low watermark is a
         // data-loss partition. In message mode with skip_data_loss_partitions
-        // on, its fetch is skipped so no timestamp is produced. It must still
-        // emit exact offset lag and lag_seconds = 0 (not None, not inflated)
-        // with data_loss_detected set.
+        // on, its fetch is skipped so no timestamp is produced. It must emit
+        // 0 offset lag (the gap is unconsumable; magnitude lives in
+        // messages_lost / retention_margin) and lag_seconds = 0 (not None, not
+        // inflated) with data_loss_detected set.
         let mut watermarks = HashMap::new();
         // low = 100, high = 500: retention has advanced past the committed offset.
         watermarks.insert(TopicPartition::new("topic1", 0), (100, 500));
@@ -451,7 +457,18 @@ mod tests {
             .find(|m| m.topic == "topic1" && m.partition == 0)
             .unwrap();
         assert!(p0.data_loss_detected, "committed < low ⇒ data loss");
-        assert_eq!(p0.lag, 460, "offset lag stays exact: 500 - 40");
+        assert_eq!(
+            p0.lag, 0,
+            "data-loss offset lag reported as 0: gap is unconsumable"
+        );
+        assert_eq!(
+            p0.messages_lost, 60,
+            "messages_lost carries magnitude: low(100) - committed(40)"
+        );
+        assert_eq!(
+            p0.retention_margin, -60,
+            "retention_margin negative under data loss: committed(40) - low(100)"
+        );
         assert_eq!(
             p0.lag_seconds,
             Some(0.0),

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -410,6 +410,56 @@ mod tests {
     }
 
     #[test]
+    fn data_loss_partition_without_timestamp_emits_zero_seconds() {
+        // A partition whose committed offset is below the low watermark is a
+        // data-loss partition. In message mode with skip_data_loss_partitions
+        // on, its fetch is skipped so no timestamp is produced. It must still
+        // emit exact offset lag and lag_seconds = 0 (not None, not inflated)
+        // with data_loss_detected set.
+        let mut watermarks = HashMap::new();
+        // low = 100, high = 500: retention has advanced past the committed offset.
+        watermarks.insert(TopicPartition::new("topic1", 0), (100, 500));
+        let mut offsets = HashMap::new();
+        offsets.insert(TopicPartition::new("topic1", 0), 40); // 40 < low(100)
+
+        let snapshot = OffsetsSnapshot {
+            cluster_name: "test-cluster".to_string(),
+            groups: vec![GroupSnapshot {
+                group_id: "test-group".to_string(),
+                state: "Stable".to_string(),
+                members: vec![],
+                offsets,
+            }],
+            watermarks,
+            compacted_topics: HashSet::new(),
+            timestamp_ms: 1_000_000,
+        };
+
+        // Empty timestamps: mirrors the fetch being skipped for this partition.
+        let metrics = LagCalculator::calculate(
+            &snapshot,
+            &HashMap::new(),
+            1_000_000,
+            100,
+            &HashSet::new(),
+            true,
+        );
+
+        let p0 = metrics
+            .partition_metrics
+            .iter()
+            .find(|m| m.topic == "topic1" && m.partition == 0)
+            .unwrap();
+        assert!(p0.data_loss_detected, "committed < low ⇒ data loss");
+        assert_eq!(p0.lag, 460, "offset lag stays exact: 500 - 40");
+        assert_eq!(
+            p0.lag_seconds,
+            Some(0.0),
+            "data-loss partition with no timestamp must emit lag_seconds = 0, not a gap"
+        );
+    }
+
+    #[test]
     fn disabled_time_lag_omits_all_lag_seconds() {
         // timestamp_sampling.enabled = false ⇒ seconds-of-lag is never
         // derived. Every partition (caught-up AND lagging) and every group

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -287,8 +287,9 @@ async fn compute_time_lags_message(
             // Retention has deleted the committed message when the committed
             // offset is below the low watermark. A fetch there can only time
             // out or read the wrong (earliest) message, so skip it when asked:
-            // the lag calculator still emits exact offset lag and a time lag of
-            // 0 with `data_loss_detected`.
+            // the lag calculator still reports the partition, with offset lag
+            // and time lag both 0 and `data_loss_detected` set (magnitude in
+            // `messages_lost` / `retention_margin`).
             if skip_data_loss_partitions && *committed_offset < low {
                 continue;
             }

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -98,6 +98,30 @@ impl MessageSampler {
         Ok(fetch_result.map(|r| r.timestamp_ms))
     }
 
+    /// Scan back from the committed offset to the last readable data record, for a
+    /// consumer wedged at the last stable offset (behind an open transaction).
+    /// Transaction control markers just below the committed offset are never
+    /// delivered, so a read there returns `None`; walk back past them — bounded,
+    /// with a short per-probe timeout — to the data record. Bypasses the cache
+    /// (the committed offset is frozen, so nothing useful is cached for it).
+    fn scan_back_for_stable_timestamp(
+        &self,
+        tp: &TopicPartition,
+        committed: i64,
+        low: i64,
+    ) -> Option<i64> {
+        for offset in fallback_scan_offsets(committed, low) {
+            if let Ok(Some(r)) =
+                self.inner
+                    .consumer
+                    .fetch_timestamp_within(tp, offset, FALLBACK_PROBE_TIMEOUT)
+            {
+                return Some(r.timestamp_ms);
+            }
+        }
+        None
+    }
+
     fn recycle_pool(&self) -> Result<()> {
         self.inner.consumer.recycle_pool()
     }
@@ -250,6 +274,9 @@ async fn compute_time_lags_message(
     skip_data_loss_partitions: bool,
 ) -> HashMap<(String, TopicPartition), TimestampData> {
     let mut requests: Vec<(String, TopicPartition, i64)> = Vec::new();
+    // Low watermark per requested (group, tp): lets a `None` fetch fall back to
+    // the last stable message without ever reading below the retention floor.
+    let mut low_by_key: HashMap<(String, TopicPartition), i64> = HashMap::new();
     for group in &snapshot.groups {
         for (tp, committed_offset) in &group.offsets {
             let (low, high) = snapshot
@@ -264,6 +291,8 @@ async fn compute_time_lags_message(
                 continue;
             }
             if high - *committed_offset > 0 {
+                let key = (group.group_id.clone(), tp.clone());
+                low_by_key.insert(key, low);
                 requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
             }
         }
@@ -278,7 +307,113 @@ async fn compute_time_lags_message(
         "Fetching per-partition message timestamps (message mode)"
     );
 
-    let semaphore = Arc::new(Semaphore::new(max_concurrent_fetches.max(1)));
+    let mut out = HashMap::new();
+
+    // Pass 1: the committed offset itself.
+    let mut fallbacks: Vec<(String, TopicPartition, i64, i64)> = Vec::new();
+    for (group_id, tp, committed, ts) in
+        fetch_timestamps_at(sampler, requests, max_concurrent_fetches).await
+    {
+        match ts {
+            Some(ts) => {
+                out.insert((group_id, tp), TimestampData { timestamp_ms: ts });
+            }
+            None => {
+                // No readable message at the committed offset: it is the first
+                // uncommitted offset (the last stable offset) — e.g. a consumer
+                // wedged behind an open/hung transaction while the high watermark
+                // keeps advancing. Don't drop the series; pass 2 scans back to the
+                // last readable data record so the partition still reports its real,
+                // growing time lag instead of vanishing.
+                let low = low_by_key
+                    .get(&(group_id.clone(), tp.clone()))
+                    .copied()
+                    .unwrap_or(committed);
+                fallbacks.push((group_id, tp, committed, low));
+            }
+        }
+    }
+
+    // Pass 2: for partitions whose committed offset was unreadable (wedged behind
+    // an open transaction), scan back to the last readable data record, skipping
+    // any transaction control markers. A miss here is unexpected — we could not
+    // read any data record near the committed offset — so it is warned, not
+    // silently dropped.
+    if !fallbacks.is_empty() {
+        debug!(
+            fallback_count = fallbacks.len(),
+            "Scanning back to last readable data record for wedged partitions"
+        );
+        let semaphore = Arc::new(Semaphore::new(max_concurrent_fetches.max(1)));
+        let mut handles = Vec::with_capacity(fallbacks.len());
+        for (group_id, tp, committed, low) in fallbacks {
+            let permit = Arc::clone(&semaphore);
+            let sampler = sampler.clone();
+            handles.push(tokio::spawn(async move {
+                let permit_guard: OwnedSemaphorePermit =
+                    permit.acquire_owned().await.expect("semaphore closed");
+                tokio::task::spawn_blocking(move || {
+                    let _p = permit_guard;
+                    let ts = sampler.scan_back_for_stable_timestamp(&tp, committed, low);
+                    (group_id, tp, ts)
+                })
+                .await
+            }));
+        }
+        for result in join_all(handles).await {
+            match result {
+                Ok(Ok((group_id, tp, Some(ts)))) => {
+                    out.insert((group_id, tp), TimestampData { timestamp_ms: ts });
+                }
+                Ok(Ok((group_id, tp, None))) => {
+                    warn!(
+                        group = %group_id,
+                        topic = %tp.topic,
+                        partition = tp.partition,
+                        "No readable data record near committed offset; time lag unavailable this cycle"
+                    );
+                }
+                Ok(Err(e)) => warn!(error = %e, "Fallback scan blocking task panicked"),
+                Err(e) => warn!(error = %e, "Fallback scan task panicked"),
+            }
+        }
+    }
+    out
+}
+
+/// Max offsets to walk back looking for the last readable data record when the
+/// committed offset is unreadable. Bounds a pathological run of transaction
+/// control markers (each occupies an offset but is never delivered to consumers).
+const FALLBACK_SCAN_MAX: i64 = 8;
+
+/// Short per-probe timeout for the fallback scan. A readable data record returns
+/// in well under this; a miss (a control marker or the last stable offset) blocks
+/// until the timeout, so keep it short to avoid tying up a fetch slot.
+const FALLBACK_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Offsets to probe, nearest-first, when the committed message is unreadable: the
+/// committed offset is the first uncommitted message, and one or more transaction
+/// control markers may sit just below it. Walks back from `committed - 1`,
+/// stopping at the retention floor or after [`FALLBACK_SCAN_MAX`] steps. Empty
+/// when the committed offset is on the retention floor.
+fn fallback_scan_offsets(committed: i64, low: i64) -> Vec<i64> {
+    let floor = low.max(0);
+    (1..=FALLBACK_SCAN_MAX)
+        .map(|k| committed - k)
+        .take_while(|&o| o >= floor)
+        .collect()
+}
+
+/// Fetch message timestamps for each `(group, tp, offset)` request, bounded by
+/// `max_concurrent`. Fetch errors and task panics are logged and surface as a
+/// `None` timestamp so a failed row never silently disappears; the returned offset
+/// echoes the request so callers can react per row.
+async fn fetch_timestamps_at(
+    sampler: &MessageSampler,
+    requests: Vec<(String, TopicPartition, i64)>,
+    max_concurrent: usize,
+) -> Vec<(String, TopicPartition, i64, Option<i64>)> {
+    let semaphore = Arc::new(Semaphore::new(max_concurrent.max(1)));
     let mut handles = Vec::with_capacity(requests.len());
     for (group_id, tp, offset) in requests {
         let permit = Arc::clone(&semaphore);
@@ -286,41 +421,34 @@ async fn compute_time_lags_message(
         handles.push(tokio::spawn(async move {
             let permit_guard: OwnedSemaphorePermit =
                 permit.acquire_owned().await.expect("semaphore closed");
-            let result = tokio::task::spawn_blocking(move || {
+            tokio::task::spawn_blocking(move || {
                 let _p = permit_guard;
-                let result = sampler.get_timestamp(&group_id, &tp, offset);
-                ((group_id, tp), result)
+                let ts = match sampler.get_timestamp(&group_id, &tp, offset) {
+                    Ok(ts) => ts,
+                    Err(e) => {
+                        warn!(
+                            group = %group_id,
+                            topic = %tp.topic,
+                            partition = tp.partition,
+                            offset,
+                            error = %e,
+                            "Message timestamp fetch failed"
+                        );
+                        None
+                    }
+                };
+                (group_id, tp, offset, ts)
             })
-            .await;
-            result
+            .await
         }));
     }
 
-    let results = join_all(handles).await;
-    let mut out = HashMap::new();
-    for result in results {
+    let mut out = Vec::with_capacity(handles.len());
+    for result in join_all(handles).await {
         match result {
-            Ok(Ok(((group_id, tp), Ok(Some(ts))))) => {
-                out.insert((group_id, tp), TimestampData { timestamp_ms: ts });
-            }
-            Ok(Ok(((_group_id, _tp), Ok(None)))) => {
-                // No message available at offset; skip.
-            }
-            Ok(Ok(((group_id, tp), Err(e)))) => {
-                warn!(
-                    group = %group_id,
-                    topic = %tp.topic,
-                    partition = tp.partition,
-                    error = %e,
-                    "Message timestamp fetch failed"
-                );
-            }
-            Ok(Err(e)) => {
-                warn!(error = %e, "Message timestamp blocking task panicked");
-            }
-            Err(e) => {
-                warn!(error = %e, "Message timestamp task panicked");
-            }
+            Ok(Ok(entry)) => out.push(entry),
+            Ok(Err(e)) => warn!(error = %e, "Message timestamp blocking task panicked"),
+            Err(e) => warn!(error = %e, "Message timestamp task panicked"),
         }
     }
     out
@@ -344,6 +472,23 @@ impl std::fmt::Debug for TimestampSampler {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fallback_scan_offsets_walks_back_bounded_by_floor() {
+        // Wedged consumer well above the low watermark: probe committed-1 down to
+        // committed-FALLBACK_SCAN_MAX, nearest first.
+        assert_eq!(
+            fallback_scan_offsets(775060, 771303),
+            vec![775059, 775058, 775057, 775056, 775055, 775054, 775053, 775052]
+        );
+        // Stops at the retention floor.
+        assert_eq!(fallback_scan_offsets(771305, 771303), vec![771304, 771303]);
+        // Committed on the retention floor: nothing stable below it.
+        assert!(fallback_scan_offsets(771303, 771303).is_empty());
+        // committed=1, low=0 -> offset 0 is the earliest readable record.
+        assert_eq!(fallback_scan_offsets(1, 0), vec![0]);
+        assert!(fallback_scan_offsets(0, 0).is_empty());
+    }
 
     #[test]
     fn cached_timestamp_ttl_expiry_check() {

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -164,20 +164,29 @@ impl TimestampSampler {
     /// `LagCalculator::calculate`.
     ///
     /// - Message mode: spawn up to `max_concurrent_fetches` blocking FFI
-    ///   tasks via the consumer pool. Unchanged behavior from Tier 2.
+    ///   tasks via the consumer pool. When `skip_data_loss_partitions` is set,
+    ///   partitions whose committed offset is below the low watermark are not
+    ///   fetched (retention deleted the committed message).
     /// - Rate mode: record this cycle's watermarks into the history ring
     ///   buffer, then synthesize `timestamp_ms = now_ms - estimate_secs *
     ///   1000` for each laggy partition where a reliable rate is available.
-    ///   `max_concurrent_fetches` is ignored.
+    ///   `max_concurrent_fetches` and `skip_data_loss_partitions` are ignored.
     pub async fn compute_time_lags(
         &self,
         snapshot: &OffsetsSnapshot,
         now_ms: i64,
         max_concurrent_fetches: usize,
+        skip_data_loss_partitions: bool,
     ) -> HashMap<(String, TopicPartition), TimestampData> {
         match self {
             Self::Message(s) => {
-                compute_time_lags_message(s, snapshot, max_concurrent_fetches).await
+                compute_time_lags_message(
+                    s,
+                    snapshot,
+                    max_concurrent_fetches,
+                    skip_data_loss_partitions,
+                )
+                .await
             }
             Self::Rate(s) => compute_time_lags_rate(s, snapshot, now_ms),
         }
@@ -238,13 +247,22 @@ async fn compute_time_lags_message(
     sampler: &MessageSampler,
     snapshot: &OffsetsSnapshot,
     max_concurrent_fetches: usize,
+    skip_data_loss_partitions: bool,
 ) -> HashMap<(String, TopicPartition), TimestampData> {
     let mut requests: Vec<(String, TopicPartition, i64)> = Vec::new();
     for group in &snapshot.groups {
         for (tp, committed_offset) in &group.offsets {
-            let high = snapshot
+            let (low, high) = snapshot
                 .get_watermark(tp)
-                .map_or(*committed_offset, |(_, h)| h);
+                .unwrap_or((*committed_offset, *committed_offset));
+            // Retention has deleted the committed message when the committed
+            // offset is below the low watermark. A fetch there can only time
+            // out or read the wrong (earliest) message, so skip it when asked:
+            // the lag calculator still emits exact offset lag and a time lag of
+            // 0 with `data_loss_detected`.
+            if skip_data_loss_partitions && *committed_offset < low {
+                continue;
+            }
             if high - *committed_offset > 0 {
                 requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
             }
@@ -361,7 +379,7 @@ mod tests {
         };
         let _ = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(sampler.compute_time_lags(&snap1, 0, 1));
+            .block_on(sampler.compute_time_lags(&snap1, 0, 1, false));
 
         std::thread::sleep(Duration::from_millis(100));
 
@@ -386,7 +404,7 @@ mod tests {
         let now_ms = 1_000_000_000i64;
         let out = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(sampler.compute_time_lags(&snap2, now_ms, 1));
+            .block_on(sampler.compute_time_lags(&snap2, now_ms, 1, false));
 
         let ts = out
             .get(&("g".to_string(), tp_key))

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -325,14 +325,16 @@ async fn compute_time_lags_message(
                     .get(&(group_id.clone(), tp.clone()))
                     .copied()
                     .unwrap_or(committed);
-                if committed <= low {
-                    // Committed offset is at or below the low watermark: the
-                    // committed message was purged (retention / Streams
-                    // deleteRecords caught up to it between the offset snapshot
-                    // and this fetch — a data-loss race the snapshot-time skip
-                    // check missed). Nothing stable remains to timestamp; report
-                    // 0, matching data-loss handling, rather than scanning and
-                    // warning.
+                if committed < low {
+                    // Committed offset is below the low watermark: the committed
+                    // message was purged (retention / Streams deleteRecords
+                    // caught up to it between the offset snapshot and this fetch
+                    // — a data-loss race the snapshot-time skip check missed).
+                    // Matches the `committed < low_watermark` data-loss test in
+                    // the lag calculator; report 0. A committed offset exactly at
+                    // `low` is still readable, so it is NOT data loss — it falls
+                    // through to the bounded scan below (which finds nothing and
+                    // warns).
                     out.insert(
                         (group_id, tp),
                         TimestampData {

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -394,8 +394,12 @@ async fn compute_time_lags_message(
                         "No readable data record near committed offset; time lag unavailable this cycle"
                     );
                 }
-                Ok(Err(e)) => warn!(error = %e, "Fallback scan blocking task panicked"),
-                Err(e) => warn!(error = %e, "Fallback scan task panicked"),
+                Ok(Err(e)) => {
+                    warn!(error = %e, kind = if e.is_panic() { "panic" } else { "cancelled" }, "Fallback scan blocking task did not complete")
+                }
+                Err(e) => {
+                    warn!(error = %e, kind = if e.is_panic() { "panic" } else { "cancelled" }, "Fallback scan task did not complete")
+                }
             }
         }
     }
@@ -468,8 +472,12 @@ async fn fetch_timestamps_at(
     for result in join_all(handles).await {
         match result {
             Ok(Ok(entry)) => out.push(entry),
-            Ok(Err(e)) => warn!(error = %e, "Message timestamp blocking task panicked"),
-            Err(e) => warn!(error = %e, "Message timestamp task panicked"),
+            Ok(Err(e)) => {
+                warn!(error = %e, kind = if e.is_panic() { "panic" } else { "cancelled" }, "Message timestamp blocking task did not complete")
+            }
+            Err(e) => {
+                warn!(error = %e, kind = if e.is_panic() { "panic" } else { "cancelled" }, "Message timestamp task did not complete")
+            }
         }
     }
     out

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -207,6 +207,7 @@ impl TimestampSampler {
                 compute_time_lags_message(
                     s,
                     snapshot,
+                    now_ms,
                     max_concurrent_fetches,
                     skip_data_loss_partitions,
                 )
@@ -270,6 +271,7 @@ fn compute_time_lags_rate(
 async fn compute_time_lags_message(
     sampler: &MessageSampler,
     snapshot: &OffsetsSnapshot,
+    now_ms: i64,
     max_concurrent_fetches: usize,
     skip_data_loss_partitions: bool,
 ) -> HashMap<(String, TopicPartition), TimestampData> {
@@ -319,17 +321,28 @@ async fn compute_time_lags_message(
                 out.insert((group_id, tp), TimestampData { timestamp_ms: ts });
             }
             None => {
-                // No readable message at the committed offset: it is the first
-                // uncommitted offset (the last stable offset) — e.g. a consumer
-                // wedged behind an open/hung transaction while the high watermark
-                // keeps advancing. Don't drop the series; pass 2 scans back to the
-                // last readable data record so the partition still reports its real,
-                // growing time lag instead of vanishing.
                 let low = low_by_key
                     .get(&(group_id.clone(), tp.clone()))
                     .copied()
                     .unwrap_or(committed);
-                fallbacks.push((group_id, tp, committed, low));
+                if committed <= low {
+                    // Committed offset is at or below the low watermark: the
+                    // committed message was purged (retention / Streams
+                    // deleteRecords caught up to it between the offset snapshot
+                    // and this fetch — a data-loss race the snapshot-time skip
+                    // check missed). Nothing stable remains to timestamp; report
+                    // 0, matching data-loss handling, rather than scanning and
+                    // warning.
+                    out.insert((group_id, tp), TimestampData { timestamp_ms: now_ms });
+                } else {
+                    // Committed offset is above the low watermark but unreadable:
+                    // it is the first uncommitted offset (the last stable offset),
+                    // e.g. a consumer wedged behind an open/hung transaction while
+                    // the high watermark keeps advancing. Don't drop the series;
+                    // pass 2 scans back to the last readable data record so the
+                    // partition still reports its real, growing time lag.
+                    fallbacks.push((group_id, tp, committed, low));
+                }
             }
         }
     }

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -333,7 +333,12 @@ async fn compute_time_lags_message(
                     // check missed). Nothing stable remains to timestamp; report
                     // 0, matching data-loss handling, rather than scanning and
                     // warning.
-                    out.insert((group_id, tp), TimestampData { timestamp_ms: now_ms });
+                    out.insert(
+                        (group_id, tp),
+                        TimestampData {
+                            timestamp_ms: now_ms,
+                        },
+                    );
                 } else {
                     // Committed offset is above the low watermark but unreadable:
                     // it is the first uncommitted offset (the last stable offset),

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,14 @@ pub struct TimestampSamplingConfig {
     /// `rate` mode (rate mode does no I/O).
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: usize,
+    /// `message` mode: skip the per-message fetch for partitions whose
+    /// committed offset is below the partition's low watermark. Retention has
+    /// already deleted the committed message, so the fetch can only time out
+    /// or read the wrong (earliest) message; the partition still emits exact
+    /// offset lag and a time lag of 0 with `data_loss_detected`. Off by
+    /// default. Ignored in `rate` mode.
+    #[serde(default = "default_skip_data_loss_partitions")]
+    pub skip_data_loss_partitions: bool,
     /// `rate` mode: maximum number of (time, `high_watermark`) samples
     /// retained per partition. Larger = smoother rate estimate, more
     /// memory. Default 5.
@@ -256,6 +264,10 @@ const fn default_max_concurrent_fetches() -> usize {
     5
 }
 
+const fn default_skip_data_loss_partitions() -> bool {
+    false
+}
+
 const fn default_timestamp_sampling_mode() -> TimestampSamplingMode {
     TimestampSamplingMode::Rate
 }
@@ -351,6 +363,7 @@ impl Default for TimestampSamplingConfig {
             mode: default_timestamp_sampling_mode(),
             cache_ttl: default_cache_ttl(),
             max_concurrent_fetches: default_max_concurrent_fetches(),
+            skip_data_loss_partitions: default_skip_data_loss_partitions(),
             rate_history_samples: default_rate_history_samples(),
             rate_history_max_age: default_rate_history_max_age(),
             rate_min_msgs_per_sec: default_rate_min_msgs_per_sec(),
@@ -789,6 +802,10 @@ bootstrap_servers = "localhost:9092"
             TimestampSamplingMode::Rate,
             "default mode should be rate (Tier 3)"
         );
+        assert!(
+            !config.exporter.timestamp_sampling.skip_data_loss_partitions,
+            "skip_data_loss_partitions should default to false"
+        );
         assert!(!config.exporter.otel.enabled);
         // Performance defaults
         assert_eq!(
@@ -819,6 +836,25 @@ bootstrap_servers = "localhost:9092"
             config.exporter.staleness_threshold.is_none(),
             "staleness_threshold should default to None (falls back to poll_interval * 3)"
         );
+    }
+
+    #[test]
+    fn test_skip_data_loss_partitions_parses() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+skip_data_loss_partitions = true
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let config = Config::load(Some(file.path().to_str().unwrap())).unwrap();
+        assert!(config.exporter.timestamp_sampling.skip_data_loss_partitions);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,9 +83,10 @@ pub struct TimestampSamplingConfig {
     /// `message` mode: skip the per-message fetch for partitions whose
     /// committed offset is below the partition's low watermark. Retention has
     /// already deleted the committed message, so the fetch can only time out
-    /// or read the wrong (earliest) message; the partition still emits exact
-    /// offset lag and a time lag of 0 with `data_loss_detected`. Off by
-    /// default. Ignored in `rate` mode.
+    /// or read the wrong (earliest) message; the partition is still reported,
+    /// with offset lag and time lag both 0 and `data_loss_detected` set (the
+    /// unconsumable magnitude is carried by `messages_lost` / `retention_margin`).
+    /// Off by default. Ignored in `rate` mode.
     #[serde(default = "default_skip_data_loss_partitions")]
     pub skip_data_loss_partitions: bool,
     /// `rate` mode: maximum number of (time, `high_watermark`) samples

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -115,11 +115,25 @@ impl TimestampConsumer {
         // else: pool is full, consumer is dropped
     }
 
-    #[instrument(skip(self), fields(cluster = %self.cluster_name, topic = %tp.topic, partition = tp.partition, offset = offset))]
+    /// Fetch the message timestamp at `offset` using the configured fetch timeout.
     pub fn fetch_timestamp(
         &self,
         tp: &TopicPartition,
         offset: i64,
+    ) -> Result<Option<TimestampFetchResult>> {
+        self.fetch_timestamp_within(tp, offset, self.fetch_timeout)
+    }
+
+    /// Fetch the message timestamp at `offset`, bounding the poll to `timeout`.
+    /// The wedged-partition fallback scan uses this with a short timeout: a miss
+    /// (a transaction control marker or the last stable offset) blocks until the
+    /// timeout, so it should not tie up a slot for the full configured duration.
+    #[instrument(skip(self), fields(cluster = %self.cluster_name, topic = %tp.topic, partition = tp.partition, offset = offset))]
+    pub fn fetch_timestamp_within(
+        &self,
+        tp: &TopicPartition,
+        offset: i64,
+        timeout: Duration,
     ) -> Result<Option<TimestampFetchResult>> {
         use rdkafka::TopicPartitionList;
 
@@ -150,7 +164,7 @@ impl TimestampConsumer {
 
         consumer.assign(&tpl).map_err(KlagError::Kafka)?;
 
-        let result = consumer.poll(self.fetch_timeout).map_or_else(
+        let result = consumer.poll(timeout).map_or_else(
             || {
                 debug!(
                     topic = %tp.topic,

--- a/src/metrics/registry.rs
+++ b/src/metrics/registry.rs
@@ -126,6 +126,16 @@ impl MetricsRegistry {
                         HELP_GROUP_OFFSET,
                     ));
 
+                    // compaction_detected / data_loss_detected annotate the lag metrics
+                    labels.insert(
+                        LABEL_COMPACTION_DETECTED.to_string(),
+                        m.compaction_detected.to_string(),
+                    );
+                    labels.insert(
+                        LABEL_DATA_LOSS_DETECTED.to_string(),
+                        m.data_loss_detected.to_string(),
+                    );
+
                     points.push(MetricPoint::gauge(
                         METRIC_GROUP_LAG,
                         labels.clone(),
@@ -134,15 +144,6 @@ impl MetricsRegistry {
                     ));
 
                     if let Some(lag_seconds) = m.lag_seconds {
-                        // Add compaction_detected and data_loss_detected labels to lag_seconds metric
-                        labels.insert(
-                            LABEL_COMPACTION_DETECTED.to_string(),
-                            m.compaction_detected.to_string(),
-                        );
-                        labels.insert(
-                            LABEL_DATA_LOSS_DETECTED.to_string(),
-                            m.data_loss_detected.to_string(),
-                        );
                         points.push(MetricPoint::gauge(
                             METRIC_GROUP_LAG_SECONDS,
                             labels.clone(),


### PR DESCRIPTION
## Summary
- Adds `exporter.timestamp_sampling.skip_data_loss_partitions` (default `false`):
  when a partition's committed offset has been purged below the low watermark,
  retention has already deleted the un-read data, so skip the message fetch and
  emit `*_lag_seconds = 0` with `data_loss_detected="true"`. A `0` here means
  "the data is gone", not "caught up".
- Surfaced as a Helm chart value.
- Ships with three correctness fixes for message-mode lag on transaction-wedged
  and retention-purged partitions (see *Fixes included*).

Companion to #97 — together these are the two asks in #94 (expose
`fetch_timeout`; skip retention-unavailable offsets). Does **not** close #94 on
its own. If #97 merges first this branch needs a small rebase — both touch
`config.rs`, `config.example.toml`, `README.md`, and the two helm files, but the
edits are additive/adjacent, no logical conflict.

## Background
In message mode, a partition with `lag > 0` seeks to the committed offset and
polls for the message there. Two real-world states break that poll:

1. **Retention-purged (data loss).** The committed offset has aged out below the
   log start (`committed < low_watermark`) — retention has deleted the un-read
   data. There is no committed message left to read, so there is no real time
   lag to compute: the consumer isn't behind on data that exists, the data is
   simply gone. Left alone the fetch can only time out or read the wrong
   (earliest) message, and on a drained partition it blocks the full fetch
   timeout — the message-mode scaling problem behind #94.
   `skip_data_loss_partitions` short-circuits these: emit `0` +
   `data_loss_detected` and move on, driving the idle-fetch count toward zero.

2. **Transaction-wedged.** A consumer parked at `committed == last_stable_offset
   < high_watermark` (behind an open/hung transaction) is *wedged*, not caught
   up. The poll at the LSO returns `None` (the next record is a transaction
   control marker), so the `*_lag_seconds` series would simply **vanish** —
   silently hiding a stuck consumer that our in-house exporter flags loudly.

## Fixes included
Message-mode correctness fixes, found while validating the skip feature and
shipped with it. They apply in message mode **regardless of the flag** —
`skip_data_loss_partitions` only gates whether the doomed fetch is *attempted*;
the reported values (`0` + `data_loss_detected`, never-vanishing wedge time-lag)
are the same either way:

- **Report time lag for consumers wedged at the last stable offset** — instead of
  dropping the series when the LSO poll returns `None`, do a bounded backward
  scan (floored by the low watermark, short probe timeout) to timestamp the last
  stable message and report the real stuck-time, so the series never vanishes.
  If even the bounded scan finds nothing readable, it logs a warning (with the
  topic / partition / offset) and skips that partition rather than emitting a
  bogus value.
- **Report `0` time lag for offsets purged below the low watermark** — when the
  committed offset is below the low watermark, retention has deleted the data it
  pointed at; there is nothing to timestamp and no real lag to report — the lag
  isn't real, the data isn't there. Emit `0` + `data_loss_detected` rather than
  scanning or reporting a misleading age.
- **Report `0` offset lag for offsets purged below the low watermark** — the
  offset-lag path was asymmetric: it still reported raw `high_watermark −
  committed` (a large phantom value) on data-loss partitions while
  `data_loss_detected` sat only on `*_lag_seconds`. The gap above a purged offset
  is unconsumable — that lag isn't real, the data is gone — so offset lag now
  reads `0` under data loss and carries the `data_loss_detected` /
  `compaction_detected` labels; the true magnitude stays in `messages_lost` /
  `retention_margin`.

## Changes
- `src/config.rs` — `skip_data_loss_partitions` field + validation.
- `src/collector/timestamp_sampler.rs` — skip + bounded-backward-scan logic.
- `src/collector/lag_calculator.rs` — data-loss offset lag = `0`.
- `src/metrics/registry.rs` — `data_loss_detected`/`compaction_detected` labels on
  the offset-lag metric.
- `src/kafka/consumer.rs` — `fetch_timestamp_within(timeout)` for the bounded probe.
- `src/cluster/manager.rs` — thread the flag through to the sampler.
- `helm/klag-exporter/{values.yaml,templates/configmap.yaml}` — chart value.
- `README.md`, `config.example.toml` — documented.

## Validation
Beyond unit tests, validated against **live in-house Kafka (staging and
production)**, exercising the real states above:
- Transaction-wedged partitions: series no longer vanishes and the reported
  stuck-time tracks the actual wedge — cross-checked against broker ground truth
  (`read_committed` LSO vs `read_uncommitted` HW) and our in-house exporter.
- Retention-purged partitions: `0` + `data_loss_detected` on both lag metrics,
  `messages_lost`/`retention_margin` carrying the magnitude.
- Before/after by aborting the hung transactions: reported lag dropped to `0` as
  the wedge cleared, matching our in-house exporter.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — green (incl. data-loss / wedge unit tests)
- [x] `cargo build --release` — clean
- [x] `helm lint` + `helm template` — clean
- [x] End-to-end against a real broker: manufactured data-loss + healthy-lagging
      partitions, off↔on contrast, plus a full-lifecycle soak
      (active → idle → retention-loss → recovery) — no gaps, no NaN, no timeouts.
