### PR TITLE
feat(helm): expose max_blocking_threads

### DIFF
--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -51,6 +51,7 @@ data:
     offset_fetch_timeout = {{ .offset_fetch_timeout | quote }}
     max_concurrent_groups = {{ .max_concurrent_groups }}
     max_concurrent_watermarks = {{ .max_concurrent_watermarks }}
+    max_blocking_threads = {{ .max_blocking_threads }}
     client_recycle_interval = {{ .client_recycle_interval }}
     {{- end }}
 

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -156,6 +156,10 @@ config:
     max_concurrent_groups: 10
     # Maximum partitions to fetch watermarks for in parallel
     max_concurrent_watermarks: 50
+    # Tokio blocking-thread pool. Shared by ALL cluster loops in the process, so a
+    # multi-cluster deployment needs this to exceed
+    # clusters x (max_concurrent_groups + max_concurrent_fetches).
+    max_blocking_threads: 64
     # Recycle librdkafka clients every N cycles to release accumulated metadata.
     # Set to 0 to disable. Default: 50 (~25 min at 30s poll interval).
     client_recycle_interval: 50

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -156,9 +156,9 @@ config:
     max_concurrent_groups: 10
     # Maximum partitions to fetch watermarks for in parallel
     max_concurrent_watermarks: 50
-    # Tokio blocking-thread pool. Shared by ALL cluster loops in the process, so a
-    # multi-cluster deployment needs this to exceed
-    # clusters x (max_concurrent_groups + max_concurrent_fetches).
+    # Tokio blocking-thread pool. Shared by ALL cluster loops in the process.
+    # Multi-cluster sizing: clusters * (max_concurrent_groups + sampler) + 4 headroom.
+    # sampler = timestamp_sampling.max_concurrent_fetches when enabled && mode="message", else 0.
     max_blocking_threads: 64
     # Recycle librdkafka clients every N cycles to release accumulated metadata.
     # Set to 0 to disable. Default: 50 (~25 min at 30s poll interval).


### PR DESCRIPTION
## Summary
- Renders `max_blocking_threads` in the `[exporter.performance]` block of `configmap.yaml`.
- Adds the key with its compiled default and a sizing note to `values.yaml`.

Closes #87.

We ran into this independently during internal testing, which is what prompted the PR. Monitoring several
Kafka clusters from a single pod, the compiled default of 64 was well short of what the workload needed,
and there was no way to raise it through the chart — the only option was editing the rendered ConfigMap
by hand and having the next sync revert it.

## Behavior
- Operators who don't set `config.exporter.performance.max_blocking_threads` get `64` — identical to
  the compiled default (`src/config.rs:319`), so this is a no-op for existing deployments.
- Operators who need a larger pool can now set it through values instead of hand-editing the rendered
  ConfigMap.

The pool matters because it is process-wide: one tokio runtime is built at `src/main.rs:92-95` and
every `ClusterManager` is spawned onto it (`:144`). A deployment monitoring several Kafka clusters in
one pod therefore needs the pool to cover the sum of the clusters' concurrent blocking calls, not one
cluster's.

## Changes
- `helm/klag-exporter/templates/configmap.yaml` — one rendered key, unconditional, matching the other
  five keys in that block.
- `helm/klag-exporter/values.yaml` — `max_blocking_threads: 64` with a comment on the multi-cluster
  sizing rule.

## Test plan
- [x] `helm lint ./helm/klag-exporter` passes.
- [x] `helm template` with no override renders `max_blocking_threads = 64`.
- [x] `helm template` with only `max_blocking_threads` set renders that value and inherits the other
      five `exporter.performance` keys from chart defaults.
- [x] Rendered `config.toml` parses as valid TOML in both cases.
- [x] Running with the rendered value: the exporter logs the configured pool size at startup.
