### PR TITLE
feat: skip message-mode time-lag fetch for data-loss partitions (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ rate_min_msgs_per_sec = 0.01       # below this rate → time lag reported as mi
 # Message-mode tuning (only used when mode = "message"):
 cache_ttl = "60s"
 max_concurrent_fetches = 10
+# Skip the per-message fetch for every partition whose committed offset has
+# fallen below the low watermark, i.e. retention deleted the committed message.
+# Such a fetch resets to the earliest surviving offset, and on a drained
+# partition it blocks for the full fetch timeout waiting for a message that
+# never arrives — enough of those stall the collection cycle on large clusters.
+# The partition is still reported either way, with its offset lag and
+# data_loss_detected; the trade-off is that time lag reports 0 rather than the
+# age of the earliest surviving message. Default false.
+skip_data_loss_partitions = false
 
 [exporter.otel]
 enabled = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -36,6 +36,15 @@ enabled = true
 # Message-mode settings (ignored when mode = "rate"):
 cache_ttl = "60s"
 max_concurrent_fetches = 5
+# Skip the per-message fetch for every partition whose committed offset has
+# fallen below the low watermark, i.e. retention deleted the committed message.
+# Such a fetch resets to the earliest surviving offset, and on a drained
+# partition it blocks for the full fetch timeout waiting for a message that
+# never arrives — enough of those stall the collection cycle on large clusters.
+# The partition is still reported either way, with its offset lag and
+# data_loss_detected; the trade-off is that time lag reports 0 rather than the
+# age of the earliest surviving message. Default false.
+skip_data_loss_partitions = false
 
 # Rate-mode settings (ignored when mode = "message"):
 # rate_history_samples = 5       # watermark observations per partition

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
     {{- if .max_concurrent_fetches }}
     max_concurrent_fetches = {{ .max_concurrent_fetches }}
     {{- end }}
+    {{- if hasKey . "skip_data_loss_partitions" }}
+    skip_data_loss_partitions = {{ .skip_data_loss_partitions }}
+    {{- end }}
     {{- if .rate_history_samples }}
     rate_history_samples = {{ .rate_history_samples }}
     {{- end }}

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -139,6 +139,13 @@ config:
     # Message-mode settings (ignored when mode = "rate"):
     # cache_ttl: "60s"
     # max_concurrent_fetches: 10
+    # Skip the fetch for every partition whose committed offset has fallen below
+    # the low watermark, i.e. retention deleted the committed message. Such a
+    # fetch resets to the earliest surviving offset and, on a drained partition,
+    # blocks for the full fetch timeout. The partition is still reported either
+    # way, with its offset lag and data_loss_detected; the trade-off is that time
+    # lag reports 0 rather than the age of the earliest surviving message.
+    # skip_data_loss_partitions: false
     # Rate-mode settings (ignored when mode = "message"):
     # rate_history_samples: 5
     # rate_history_max_age: "10m"

--- a/src/cluster/manager.rs
+++ b/src/cluster/manager.rs
@@ -27,6 +27,7 @@ pub struct ClusterManager {
     max_backoff: Duration,
     granularity: Granularity,
     max_concurrent_fetches: usize,
+    skip_data_loss_partitions: bool,
     cache_cleanup_interval: Duration,
     collection_timeout: Duration,
     client_recycle_interval: u64,
@@ -104,6 +105,7 @@ impl ClusterManager {
             max_backoff: Duration::from_mins(5),
             granularity: exporter_config.granularity,
             max_concurrent_fetches: exporter_config.timestamp_sampling.max_concurrent_fetches,
+            skip_data_loss_partitions: exporter_config.timestamp_sampling.skip_data_loss_partitions,
             cache_cleanup_interval: exporter_config.timestamp_sampling.cache_ttl * 2,
             collection_timeout,
             client_recycle_interval: exporter_config.performance.client_recycle_interval,
@@ -290,7 +292,12 @@ impl ClusterManager {
         // configured (rate = no I/O, message = bounded concurrent FFI).
         let timestamps = if let Some(ref sampler) = self.timestamp_sampler {
             sampler
-                .compute_time_lags(&snapshot, now_ms, self.max_concurrent_fetches)
+                .compute_time_lags(
+                    &snapshot,
+                    now_ms,
+                    self.max_concurrent_fetches,
+                    self.skip_data_loss_partitions,
+                )
                 .await
         } else {
             HashMap::new()

--- a/src/collector/lag_calculator.rs
+++ b/src/collector/lag_calculator.rs
@@ -439,6 +439,94 @@ mod tests {
     }
 
     #[test]
+    fn data_loss_partition_without_timestamp_emits_zero_seconds() {
+        // A partition whose committed offset is below the low watermark has had
+        // its committed message deleted by retention, so no timestamp can be
+        // sampled for it — an absent entry in `timestamps` is exactly what that
+        // looks like, whether the fetch failed or was deliberately skipped.
+        //
+        // It must still be reported: lag_seconds = 0 rather than omitted, the
+        // data_loss_detected flag set, and offset lag untouched. Anything that
+        // turned this into `None` would silently drop the partition from the
+        // `*_lag_seconds` families.
+        //
+        // `lagging/0` is the control: also lagging, also missing a timestamp, but
+        // NOT data loss. It must report `None`. Without it, widening the fallback
+        // to an unconditional `Some(0.0)` would pass — and that would mask real
+        // lag on every partition whose fetch merely failed.
+        let mut watermarks = HashMap::new();
+        watermarks.insert(TopicPartition::new("drained", 0), (500, 900));
+        watermarks.insert(TopicPartition::new("lagging", 0), (0, 900));
+
+        let mut offsets = HashMap::new();
+        offsets.insert(TopicPartition::new("drained", 0), 100);
+        offsets.insert(TopicPartition::new("lagging", 0), 400);
+
+        let snapshot = OffsetsSnapshot {
+            cluster_name: "test-cluster".to_string(),
+            groups: vec![GroupSnapshot {
+                group_id: "g".to_string(),
+                state: "Stable".to_string(),
+                members: vec![],
+                offsets,
+            }],
+            watermarks,
+            compacted_topics: HashSet::new(),
+            timestamp_ms: 1_000_000,
+        };
+
+        let metrics =
+            LagCalculator::calculate(&snapshot, &HashMap::new(), 0, 100, &HashSet::new(), true);
+
+        let find = |topic: &str| {
+            metrics
+                .partition_metrics
+                .iter()
+                .find(|m| m.topic == topic && m.partition == 0)
+                .unwrap_or_else(|| panic!("{topic} must still be reported"))
+        };
+
+        let drained = find("drained");
+        assert!(
+            drained.data_loss_detected,
+            "committed below low watermark is data loss"
+        );
+        assert_eq!(
+            drained.lag_seconds,
+            Some(0.0),
+            "an unsampled data-loss partition must report 0 seconds, not None"
+        );
+        assert!(
+            drained.lag > 0,
+            "offset lag does not depend on timestamp sampling"
+        );
+        assert_eq!(
+            drained.messages_lost, 400,
+            "low_watermark - committed_offset"
+        );
+        assert_eq!(
+            drained.retention_margin, -400,
+            "negative margin signals data loss"
+        );
+
+        let lagging = find("lagging");
+        assert!(
+            !lagging.data_loss_detected,
+            "committed above low watermark is not data loss"
+        );
+        assert_eq!(
+            lagging.lag_seconds, None,
+            "the zero-second fallback must apply ONLY to data loss, otherwise a \
+             failed fetch would masquerade as zero lag"
+        );
+
+        assert_eq!(
+            metrics.data_loss_partition_count, 1,
+            "exactly one of the two partitions is data loss"
+        );
+    }
+
+    #[test]
     fn test_lag_calculator_handles_negative_lag() {
         let mut watermarks = HashMap::new();
         watermarks.insert(TopicPartition::new("topic1", 0), (0, 100));

--- a/src/collector/timestamp_sampler.rs
+++ b/src/collector/timestamp_sampler.rs
@@ -164,20 +164,29 @@ impl TimestampSampler {
     /// `LagCalculator::calculate`.
     ///
     /// - Message mode: spawn up to `max_concurrent_fetches` blocking FFI
-    ///   tasks via the consumer pool. Unchanged behavior from Tier 2.
+    ///   tasks via the consumer pool. Unchanged behavior from Tier 2, except
+    ///   that `skip_data_loss_partitions` drops partitions committed below
+    ///   their low watermark before any fetch is issued.
     /// - Rate mode: record this cycle's watermarks into the history ring
     ///   buffer, then synthesize `timestamp_ms = now_ms - estimate_secs *
     ///   1000` for each laggy partition where a reliable rate is available.
-    ///   `max_concurrent_fetches` is ignored.
+    ///   `max_concurrent_fetches` and `skip_data_loss_partitions` are ignored.
     pub async fn compute_time_lags(
         &self,
         snapshot: &OffsetsSnapshot,
         now_ms: i64,
         max_concurrent_fetches: usize,
+        skip_data_loss_partitions: bool,
     ) -> HashMap<(String, TopicPartition), TimestampData> {
         match self {
             Self::Message(s) => {
-                compute_time_lags_message(s, snapshot, max_concurrent_fetches).await
+                compute_time_lags_message(
+                    s,
+                    snapshot,
+                    max_concurrent_fetches,
+                    skip_data_loss_partitions,
+                )
+                .await
             }
             Self::Rate(s) => compute_time_lags_rate(s, snapshot, now_ms),
         }
@@ -234,22 +243,45 @@ fn compute_time_lags_rate(
     out
 }
 
-async fn compute_time_lags_message(
-    sampler: &MessageSampler,
+/// Select the partitions worth fetching a message timestamp for this cycle.
+///
+/// Only lagging partitions need a fetch. When `skip_data_loss_partitions` is
+/// set, partitions whose committed offset has already fallen below the low
+/// watermark are left out as well. Performs no I/O.
+fn build_fetch_requests(
     snapshot: &OffsetsSnapshot,
-    max_concurrent_fetches: usize,
-) -> HashMap<(String, TopicPartition), TimestampData> {
+    skip_data_loss_partitions: bool,
+) -> Vec<(String, TopicPartition, i64)> {
     let mut requests: Vec<(String, TopicPartition, i64)> = Vec::new();
     for group in &snapshot.groups {
         for (tp, committed_offset) in &group.offsets {
-            let high = snapshot
+            let (low, high) = snapshot
                 .get_watermark(tp)
-                .map_or(*committed_offset, |(_, h)| h);
+                .unwrap_or((*committed_offset, *committed_offset));
+            // The committed message was deleted by retention when the committed
+            // offset is below the low watermark; a fetch there seeks out of range
+            // and, on an idle/drained partition, blocks for the full fetch timeout
+            // waiting for a message that never arrives. Skip it when asked. The
+            // lag calculator still reports the partition — offset lag, a time lag
+            // of 0, and data_loss_detected.
+            if skip_data_loss_partitions && *committed_offset < low {
+                continue;
+            }
             if high - *committed_offset > 0 {
                 requests.push((group.group_id.clone(), tp.clone(), *committed_offset));
             }
         }
     }
+    requests
+}
+
+async fn compute_time_lags_message(
+    sampler: &MessageSampler,
+    snapshot: &OffsetsSnapshot,
+    max_concurrent_fetches: usize,
+    skip_data_loss_partitions: bool,
+) -> HashMap<(String, TopicPartition), TimestampData> {
+    let requests = build_fetch_requests(snapshot, skip_data_loss_partitions);
     if requests.is_empty() {
         return HashMap::new();
     }
@@ -327,6 +359,59 @@ impl std::fmt::Debug for TimestampSampler {
 mod tests {
     use super::*;
 
+    /// Snapshot exercising every branch of [`build_fetch_requests`]:
+    ///
+    /// - `healthy/0`   — lagging, committed above the low watermark. The ordinary case.
+    /// - `boundary/0`  — lagging, committed exactly *at* the low watermark. Still
+    ///   readable, so not data loss, and must never be skipped.
+    /// - `drained/0`   — lagging, committed *below* the low watermark. Retention
+    ///   deleted the committed message; this is the partition the flag targets.
+    /// - `caught-up/0` — committed at the high watermark. No lag, so never fetched
+    ///   whatever the flag says.
+    /// - `unknown/0`   — committed but absent from `watermarks`, so the lookup
+    ///   falls back to `(committed, committed)`. Yields no lag and no data loss,
+    ///   so it is never fetched either.
+    fn skip_fixture() -> OffsetsSnapshot {
+        use crate::collector::offset_collector::{GroupSnapshot, MemberSnapshot};
+        use std::collections::HashSet;
+
+        let mut watermarks = HashMap::new();
+        watermarks.insert(TopicPartition::new("healthy", 0), (100, 900));
+        watermarks.insert(TopicPartition::new("boundary", 0), (500, 900));
+        watermarks.insert(TopicPartition::new("drained", 0), (500, 900));
+        watermarks.insert(TopicPartition::new("caught-up", 0), (0, 50));
+        // "unknown" deliberately absent from watermarks.
+
+        let mut offsets = HashMap::new();
+        offsets.insert(TopicPartition::new("healthy", 0), 400);
+        offsets.insert(TopicPartition::new("boundary", 0), 500);
+        offsets.insert(TopicPartition::new("drained", 0), 100);
+        offsets.insert(TopicPartition::new("caught-up", 0), 50);
+        offsets.insert(TopicPartition::new("unknown", 0), 700);
+
+        OffsetsSnapshot {
+            cluster_name: "c".into(),
+            groups: vec![GroupSnapshot {
+                group_id: "g".into(),
+                state: "Stable".into(),
+                members: vec![] as Vec<MemberSnapshot>,
+                offsets,
+            }],
+            watermarks,
+            compacted_topics: HashSet::new(),
+            timestamp_ms: 0,
+        }
+    }
+
+    fn topics_of(requests: &[(String, TopicPartition, i64)]) -> Vec<&str> {
+        let mut topics: Vec<&str> = requests
+            .iter()
+            .map(|(_, tp, _)| tp.topic.as_ref())
+            .collect();
+        topics.sort_unstable();
+        topics
+    }
+
     #[test]
     fn cached_timestamp_ttl_expiry_check() {
         let cached = CachedTimestamp {
@@ -361,7 +446,7 @@ mod tests {
         };
         let _ = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(sampler.compute_time_lags(&snap1, 0, 1));
+            .block_on(sampler.compute_time_lags(&snap1, 0, 1, false));
 
         std::thread::sleep(Duration::from_millis(100));
 
@@ -386,7 +471,7 @@ mod tests {
         let now_ms = 1_000_000_000i64;
         let out = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(sampler.compute_time_lags(&snap2, now_ms, 1));
+            .block_on(sampler.compute_time_lags(&snap2, now_ms, 1, false));
 
         let ts = out
             .get(&("g".to_string(), tp_key))
@@ -399,6 +484,55 @@ mod tests {
         assert!(
             lag_ms > 0 && lag_ms < 60_000,
             "synthetic lag_ms out of sanity range: {lag_ms}"
+        );
+    }
+
+    #[test]
+    fn skip_disabled_fetches_every_lagging_partition() {
+        let requests = build_fetch_requests(&skip_fixture(), false);
+        assert_eq!(
+            topics_of(&requests),
+            vec!["boundary", "drained", "healthy"],
+            "with the flag off every lagging partition is fetched, including the drained one; \
+             caught-up and watermark-less partitions are excluded regardless of the flag"
+        );
+    }
+
+    #[test]
+    fn skip_enabled_drops_only_data_loss_partitions() {
+        let requests = build_fetch_requests(&skip_fixture(), true);
+        assert_eq!(
+            topics_of(&requests),
+            vec!["boundary", "healthy"],
+            "only the partition committed below its low watermark is skipped"
+        );
+        // The boundary case is the one worth pinning: a committed offset exactly
+        // at the low watermark is still readable, so the comparison must stay
+        // strict (`<`) and never widen to `<=`.
+        assert!(
+            requests
+                .iter()
+                .any(|(_, tp, offset)| tp.topic.as_ref() == "boundary" && *offset == 500),
+            "committed == low_watermark is still readable and must be fetched"
+        );
+    }
+
+    #[test]
+    fn requests_carry_the_owning_group_and_committed_offset() {
+        // topics_of() projects away group and offset, so assert them directly —
+        // the fetch is meaningless if either is wrong.
+        let requests = build_fetch_requests(&skip_fixture(), true);
+        assert!(
+            requests.iter().all(|(group_id, _, _)| group_id == "g"),
+            "every request must name the group whose offset it came from"
+        );
+        let healthy = requests
+            .iter()
+            .find(|(_, tp, _)| tp.topic.as_ref() == "healthy")
+            .expect("healthy partition should be fetched");
+        assert_eq!(
+            healthy.2, 400,
+            "the request must carry the group's committed offset, not a watermark"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,24 @@ pub struct TimestampSamplingConfig {
     /// `rate` mode (rate mode does no I/O).
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: usize,
+    /// `message` mode: skip the per-message fetch for every partition whose
+    /// committed offset has fallen below the partition's low watermark, meaning
+    /// retention already deleted the committed message.
+    ///
+    /// Such a fetch seeks out of range and resets to the earliest surviving
+    /// offset. On a drained partition there is nothing left to read, so it
+    /// blocks for the full fetch timeout waiting for a message that never
+    /// arrives, and enough of those can stall the collection cycle on large
+    /// clusters.
+    ///
+    /// The partition is still reported either way, with its offset lag and the
+    /// `data_loss_detected` label. The trade-off is time lag: skipping reports
+    /// `0`, whereas fetching reports the age of the earliest surviving
+    /// message — already an understatement of the true lag, but not zero.
+    ///
+    /// Off by default. Ignored in `rate` mode.
+    #[serde(default)]
+    pub skip_data_loss_partitions: bool,
     /// `rate` mode: maximum number of (time, `high_watermark`) samples
     /// retained per partition. Larger = smoother rate estimate, more
     /// memory. Default 5.
@@ -351,6 +369,7 @@ impl Default for TimestampSamplingConfig {
             mode: default_timestamp_sampling_mode(),
             cache_ttl: default_cache_ttl(),
             max_concurrent_fetches: default_max_concurrent_fetches(),
+            skip_data_loss_partitions: false,
             rate_history_samples: default_rate_history_samples(),
             rate_history_max_age: default_rate_history_max_age(),
             rate_min_msgs_per_sec: default_rate_min_msgs_per_sec(),
@@ -789,6 +808,10 @@ bootstrap_servers = "localhost:9092"
             TimestampSamplingMode::Rate,
             "default mode should be rate (Tier 3)"
         );
+        assert!(
+            !config.exporter.timestamp_sampling.skip_data_loss_partitions,
+            "skip_data_loss_partitions should default to false"
+        );
         assert!(!config.exporter.otel.enabled);
         // Performance defaults
         assert_eq!(
@@ -819,6 +842,25 @@ bootstrap_servers = "localhost:9092"
             config.exporter.staleness_threshold.is_none(),
             "staleness_threshold should default to None (falls back to poll_interval * 3)"
         );
+    }
+
+    #[test]
+    fn test_skip_data_loss_partitions_parses() {
+        let config_content = r#"
+[exporter]
+
+[exporter.timestamp_sampling]
+mode = "message"
+skip_data_loss_partitions = true
+
+[[clusters]]
+name = "test"
+bootstrap_servers = "localhost:9092"
+"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+        let config = Config::load(Some(file.path().to_str().unwrap())).unwrap();
+        assert!(config.exporter.timestamp_sampling.skip_data_loss_partitions);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds `exporter.timestamp_sampling.skip_data_loss_partitions` (default `false`) and exposes it as a
chart value.

In message mode the time-lag fetch seeks to the committed offset. When retention has already deleted
that offset — committed below the low watermark — the fetch resets to the earliest surviving offset
and, on a drained partition, blocks for the full fetch timeout waiting for a message that never
arrives. Enough of those and a collection cycle stops finishing.

With the flag on, that fetch is skipped. The partition is still reported, because an absent timestamp
is a case `lag_calculator` already handles: `data_loss_detected` is derived from the watermarks, and
the existing `.or(if data_loss_detected { Some(0.0) } else { None })` fallback emits a time lag of `0`
with the label attached. Offset lag comes from the watermark path and is untouched.

References #94. #97 covers the configurable fetch timeout from that same issue; neither PR depends on
the other.

Supersedes #98.

## Behavior
- Default `false` — no change for existing deployments, and the chart renders the key only when it is
  explicitly set.
- With the flag on, a data-loss partition keeps its offset lag and carries `data_loss_detected="true"`.
  It does not disappear from `/metrics`, which matters for idle topics that should stay visible until
  their consumer groups age out.
- **The trade-off is time lag.** Fetching reports the age of the earliest surviving message — already
  an understatement, since the committed message itself is gone. Skipping reports `0`. Both understate;
  the flag trades a larger understatement for a bounded collection cycle. Anything consuming
  `*_lag_seconds` on affected partitions should filter on `data_loss_detected`.

Verified against our own internal configuration, where this has been running for several weeks: the
partitions in this state hold steady at `0` seconds of time lag while continuing to report non-zero
offset lag, and the per-cycle cost of those blocked fetches is gone.

## Changes
- `src/config.rs` — the flag and its default.
- `src/collector/timestamp_sampler.rs` — skip the fetch when the committed offset is below the low
  watermark. Request building is extracted into a pure `build_fetch_requests` so both flag states are
  testable without a broker.
- `src/cluster/manager.rs` — thread the flag through to the sampler.
- `src/collector/lag_calculator.rs` — test only; guards the zero-second fallback this feature relies on.
- `helm/` — chart value, rendered only when set.
- `README.md`, `config.example.toml` — document it, including the trade-off.

## Test plan
- [x] `cargo fmt`, `clippy`, `test`, `build` and `helm lint` all green.
- [x] Flag off: every lagging partition is fetched, including the drained one.
- [x] Flag on: only the partition committed below its low watermark is dropped. A committed offset
      exactly *at* the low watermark is still readable and is still fetched — confirmed by mutating
      `<` to `<=`, which fails the test.
- [x] Caught-up partitions, and partitions absent from `watermarks`, are never fetched either way.
- [x] A data-loss partition with no sampled timestamp reports `lag_seconds = 0`, `data_loss_detected`
      and its offset lag; a lagging *non*-data-loss partition with no timestamp reports `None` —
      confirmed by widening the fallback to an unconditional `Some(0.0)`, which fails the test.
- [x] `helm template` renders the key only when explicitly set; rendered `config.toml` parses.
