### PR TITLE
feat: Configurable retries for transient group fetch errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prometheus",
+ "rand 0.9.4",
  "rdkafka",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 tower = "0.4"
 async-trait = "0.1"
+rand = "0.9"
 
 # Kubernetes leader election (optional)
 kube = { version = "0.99", features = ["client", "runtime", "rustls-tls"], optional = true }

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ export_interval = "60s"
 # [exporter.performance]
 # kafka_timeout = "30s"
 # offset_fetch_timeout = "10s"
+# group_fetch_retries = 0
 # max_concurrent_groups = 10
 # max_concurrent_watermarks = 50
 
@@ -544,6 +545,11 @@ kafka_timeout = "30s"            # Default: 30s
 
 # Timeout for each per-group committed-offsets fetch
 offset_fetch_timeout = "10s"     # Default: 10s
+
+# Additional attempts for retriable failures while fetching consumer-group
+# descriptions and committed offsets (DescribeConsumerGroups and
+# ListConsumerGroupOffsets). Set to 0 to disable retries.
+group_fetch_retries = 2           # Default: 0
 
 # Parallel in-flight ListConsumerGroupOffsets calls (one group per call).
 # Increase on large clusters so a backlog of groups drains quickly.

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,6 +49,11 @@ max_concurrent_fetches = 5
 # Timeout for fetching committed offsets per consumer group
 # offset_fetch_timeout = "10s"
 
+# Additional attempts for retriable failures while fetching consumer-group
+# descriptions and committed offsets (DescribeConsumerGroups and
+# ListConsumerGroupOffsets). Set to 0 to disable retries.
+# group_fetch_retries = 0
+
 # Maximum consumer groups to fetch offsets for in parallel
 # max_concurrent_groups = 10
 

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -49,7 +49,7 @@ data:
     {{- with index .Values.config "exporter.performance" }}
     kafka_timeout = {{ .kafka_timeout | quote }}
     offset_fetch_timeout = {{ .offset_fetch_timeout | quote }}
-    group_fetch_retries = {{ .group_fetch_retries }}
+    group_fetch_retries = {{ .group_fetch_retries | default 0 }}
     max_concurrent_groups = {{ .max_concurrent_groups }}
     max_concurrent_watermarks = {{ .max_concurrent_watermarks }}
     client_recycle_interval = {{ .client_recycle_interval }}

--- a/helm/klag-exporter/templates/configmap.yaml
+++ b/helm/klag-exporter/templates/configmap.yaml
@@ -49,6 +49,7 @@ data:
     {{- with index .Values.config "exporter.performance" }}
     kafka_timeout = {{ .kafka_timeout | quote }}
     offset_fetch_timeout = {{ .offset_fetch_timeout | quote }}
+    group_fetch_retries = {{ .group_fetch_retries }}
     max_concurrent_groups = {{ .max_concurrent_groups }}
     max_concurrent_watermarks = {{ .max_concurrent_watermarks }}
     client_recycle_interval = {{ .client_recycle_interval }}

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -152,6 +152,10 @@ config:
     kafka_timeout: "30s"
     # Timeout for fetching committed offsets per consumer group
     offset_fetch_timeout: "10s"
+    # Additional attempts for retriable failures while fetching consumer-group
+    # descriptions and committed offsets (DescribeConsumerGroups and
+    # ListConsumerGroupOffsets). Set to 0 to disable retries.
+    group_fetch_retries: 0
     # Maximum consumer groups to fetch offsets for in parallel
     max_concurrent_groups: 10
     # Maximum partitions to fetch watermarks for in parallel

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -650,6 +650,146 @@ fn chrono_timestamp_ms() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ClusterConfig;
+    use rdkafka::mocking::{MockCluster, MockCoordinator};
+    use rdkafka::producer::DefaultProducerContext;
+    use rdkafka::types::{RDKafkaApiKey, RDKafkaRespErr};
+
+    const MOCK_GROUP: &str = "retry-test-group";
+
+    fn mock_offset_collector(
+        max_retries: usize,
+    ) -> (
+        MockCluster<'static, DefaultProducerContext>,
+        OffsetCollector,
+    ) {
+        let mock_cluster = MockCluster::new(1).expect("create mock Kafka cluster");
+        mock_cluster
+            .coordinator(MockCoordinator::Group(MOCK_GROUP.to_string()), 1)
+            .expect("set mock group coordinator");
+
+        let cluster = ClusterConfig {
+            name: "mock".to_string(),
+            bootstrap_servers: mock_cluster.bootstrap_servers(),
+            group_whitelist: vec![".*".to_string()],
+            group_blacklist: vec![],
+            topic_whitelist: vec![".*".to_string()],
+            topic_blacklist: vec![],
+            consumer_properties: HashMap::new(),
+            labels: HashMap::new(),
+        };
+        let filters = cluster.compile_filters().expect("compile filters");
+        let performance = PerformanceConfig {
+            offset_fetch_timeout: Duration::from_secs(2),
+            group_fetch_retries: max_retries,
+            max_concurrent_groups: 1,
+            ..PerformanceConfig::default()
+        };
+        let client = Arc::new(
+            KafkaClient::with_performance(&cluster, performance.clone())
+                .expect("create Kafka client"),
+        );
+        let collector =
+            OffsetCollector::with_performance(client, filters, performance, Granularity::Topic);
+
+        (mock_cluster, collector)
+    }
+
+    #[tokio::test]
+    async fn group_offset_fetch_does_not_retry_when_disabled() {
+        let (mock_cluster, collector) = mock_offset_collector(0);
+        mock_cluster.request_errors(
+            RDKafkaApiKey::OffsetFetch,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS],
+        );
+
+        let failed = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+        assert!(
+            !failed.contains_key(MOCK_GROUP),
+            "a failed group should be omitted when retries are disabled"
+        );
+
+        // The injected error is consumed by the first broker request. A second
+        // collection succeeds, proving that the first result was caused by the
+        // lack of an application-level retry rather than bad mock setup.
+        let next_collection = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+        assert!(next_collection.contains_key(MOCK_GROUP));
+    }
+
+    #[tokio::test]
+    async fn group_offset_fetch_recovers_from_one_retriable_broker_error() {
+        let (mock_cluster, collector) = mock_offset_collector(1);
+        mock_cluster.request_errors(
+            RDKafkaApiKey::OffsetFetch,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS],
+        );
+
+        let offsets = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+
+        assert!(
+            offsets.contains_key(MOCK_GROUP),
+            "the retry should recover the successful empty-offset response"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_offset_fetch_does_not_retry_transport_disconnect_when_disabled() {
+        let (mock_cluster, collector) = mock_offset_collector(0);
+        mock_cluster.request_errors(
+            RDKafkaApiKey::OffsetFetch,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR__TRANSPORT],
+        );
+
+        let failed = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+        assert!(!failed.contains_key(MOCK_GROUP));
+    }
+
+    #[tokio::test]
+    async fn group_offset_fetch_recovers_from_transport_disconnect() {
+        let (mock_cluster, collector) = mock_offset_collector(1);
+        mock_cluster.request_errors(
+            RDKafkaApiKey::OffsetFetch,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR__TRANSPORT],
+        );
+
+        let offsets = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+
+        assert!(
+            offsets.contains_key(MOCK_GROUP),
+            "the retry should reconnect after a broker transport disconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_offset_fetch_does_not_retry_permanent_broker_errors() {
+        let (mock_cluster, collector) = mock_offset_collector(1);
+        mock_cluster.request_errors(
+            RDKafkaApiKey::OffsetFetch,
+            &[RDKafkaRespErr::RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED],
+        );
+
+        let failed = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+        assert!(!failed.contains_key(MOCK_GROUP));
+
+        // If the collector had retried the permanent error, that retry would
+        // have consumed the mock broker's next (successful) response already.
+        let next_collection = collector
+            .fetch_all_group_offsets_batched(&[MOCK_GROUP])
+            .await;
+        assert!(next_collection.contains_key(MOCK_GROUP));
+    }
 
     #[test]
     fn test_offsets_snapshot_filtered_groups() {

--- a/src/collector/offset_collector.rs
+++ b/src/collector/offset_collector.rs
@@ -1,6 +1,7 @@
 use crate::config::{CompiledFilters, Granularity, PerformanceConfig};
 use crate::error::Result;
 use crate::kafka::client::{ConsumerGroupInfo, KafkaClient, TopicPartition};
+use crate::retry::{full_jitter_backoff, retry_with_backoff};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -515,7 +516,7 @@ impl OffsetCollector {
         &self,
         group_ids: &[&str],
     ) -> HashMap<String, HashMap<TopicPartition, i64>> {
-        use crate::kafka::admin::list_consumer_group_offsets_batched;
+        use crate::kafka::admin::{list_consumer_group_offsets_batched, AdminRequestError};
 
         if group_ids.is_empty() {
             return HashMap::new();
@@ -526,11 +527,13 @@ impl OffsetCollector {
 
         let offset_timeout = self.performance.offset_fetch_timeout;
         let max_concurrent = self.performance.max_concurrent_groups;
+        let max_retries = self.performance.group_fetch_retries;
 
         debug!(
             groups = group_ids.len(),
             per_call_chunk = PER_CALL_CHUNK,
             max_concurrent = max_concurrent,
+            max_retries = max_retries,
             "Fetching group offsets (one call per group, fanned out)"
         );
 
@@ -539,25 +542,52 @@ impl OffsetCollector {
 
         let mut handles = Vec::with_capacity(group_ids.len());
         for gid in group_ids {
-            let gid = gid.to_string();
+            let gid: Arc<str> = Arc::from(*gid);
             let permit = semaphore.clone();
             let client_clone = Arc::clone(&client);
             handles.push(tokio::spawn(async move {
-                let _permit: OwnedSemaphorePermit =
-                    permit.acquire_owned().await.expect("semaphore closed");
-                // Return the group id alongside the result so failure logs
-                // can report which group broke.
-                let result = tokio::task::spawn_blocking({
-                    let gid = gid.clone();
-                    move || {
-                        list_consumer_group_offsets_batched(
-                            &client_clone.admin_handle(),
-                            &[gid.as_str()],
-                            offset_timeout,
-                            PER_CALL_CHUNK,
-                        )
-                    }
-                })
+                let result = retry_with_backoff(
+                    max_retries,
+                    |attempt| {
+                        let gid = Arc::clone(&gid);
+                        let permit = Arc::clone(&permit);
+                        let client = Arc::clone(&client_clone);
+                        async move {
+                            if attempt > 1 {
+                                debug!(
+                                    group = %gid,
+                                    attempt = attempt,
+                                    max_attempts = max_retries.saturating_add(1),
+                                    "Retrying failed ListConsumerGroupOffsets request"
+                                );
+                            }
+                            // Every attempt, including retries, acquires the
+                            // same concurrency permit. Release it before any
+                            // retry backoff so sleeping calls do not occupy a
+                            // scarce blocking-operation slot.
+                            let _permit: OwnedSemaphorePermit =
+                                permit.acquire_owned().await.expect("semaphore closed");
+                            let response = tokio::task::spawn_blocking(move || {
+                                list_consumer_group_offsets_batched(
+                                    &client.admin_handle(),
+                                    &[gid.as_ref()],
+                                    offset_timeout,
+                                    PER_CALL_CHUNK,
+                                )
+                            })
+                            .await
+                            .map_err(|error| {
+                                AdminRequestError::task(
+                                    "ListConsumerGroupOffsets",
+                                    format!("blocking task failed: {error}"),
+                                )
+                            })??;
+                            response.into_single_group_result()
+                        }
+                    },
+                    AdminRequestError::is_retriable,
+                    full_jitter_backoff,
+                )
                 .await;
                 (gid, result)
             }));
@@ -568,12 +598,24 @@ impl OffsetCollector {
         let mut merged: HashMap<String, HashMap<TopicPartition, i64>> = HashMap::new();
         for r in results {
             match r {
-                Ok((_gid, Ok(Ok(map)))) => merged.extend(map),
-                Ok((gid, Ok(Err(e)))) => {
-                    warn!(group = %gid, error = %e, "Group-offset call failed");
+                Ok((gid, Ok((map, attempts)))) => {
+                    if attempts > 1 {
+                        debug!(
+                            group = %gid,
+                            attempts,
+                            "ListConsumerGroupOffsets recovered after retry"
+                        );
+                    }
+                    merged.extend(map);
                 }
-                Ok((gid, Err(e))) => {
-                    warn!(group = %gid, error = %e, "Group-offset call task panicked");
+                Ok((gid, Err(failure))) => {
+                    warn!(
+                        group = %gid,
+                        error = %failure.error,
+                        attempts = failure.attempts,
+                        stop_reason = ?failure.reason,
+                        "Group-offset call failed"
+                    );
                 }
                 Err(e) => warn!(error = %e, "Group-offset join error"),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,11 @@ pub struct PerformanceConfig {
     /// Timeout for fetching committed offsets per consumer group
     #[serde(with = "humantime_serde", default = "default_offset_fetch_timeout")]
     pub offset_fetch_timeout: Duration,
+    /// Additional attempts for retriable failures while fetching consumer-group
+    /// descriptions and committed offsets (`DescribeConsumerGroups` and
+    /// `ListConsumerGroupOffsets`). Set to 0 to disable retries.
+    #[serde(default = "default_group_fetch_retries")]
+    pub group_fetch_retries: usize,
     /// Maximum number of consumer groups to fetch offsets for in parallel
     #[serde(default = "default_max_concurrent_groups")]
     pub max_concurrent_groups: usize,
@@ -280,6 +285,10 @@ const fn default_offset_fetch_timeout() -> Duration {
     Duration::from_secs(10)
 }
 
+const fn default_group_fetch_retries() -> usize {
+    0
+}
+
 const fn default_max_concurrent_groups() -> usize {
     10
 }
@@ -387,6 +396,7 @@ impl Default for PerformanceConfig {
         Self {
             kafka_timeout: default_kafka_timeout(),
             offset_fetch_timeout: default_offset_fetch_timeout(),
+            group_fetch_retries: default_group_fetch_retries(),
             max_concurrent_groups: default_max_concurrent_groups(),
             max_concurrent_watermarks: default_max_concurrent_watermarks(),
             client_recycle_interval: default_client_recycle_interval(),
@@ -799,6 +809,7 @@ bootstrap_servers = "localhost:9092"
             config.exporter.performance.offset_fetch_timeout,
             Duration::from_secs(10)
         );
+        assert_eq!(config.exporter.performance.group_fetch_retries, 0);
         assert_eq!(config.exporter.performance.max_concurrent_groups, 10);
         assert_eq!(config.exporter.performance.max_concurrent_watermarks, 50);
         assert_eq!(config.exporter.performance.client_recycle_interval, 50);
@@ -899,6 +910,7 @@ poll_interval = "60s"
 [exporter.performance]
 kafka_timeout = "15s"
 offset_fetch_timeout = "5s"
+group_fetch_retries = 2
 max_concurrent_groups = 20
 max_concurrent_watermarks = 100
 client_recycle_interval = 0
@@ -920,6 +932,7 @@ bootstrap_servers = "localhost:9092"
             config.exporter.performance.offset_fetch_timeout,
             Duration::from_secs(5)
         );
+        assert_eq!(config.exporter.performance.group_fetch_retries, 2);
         assert_eq!(config.exporter.performance.max_concurrent_groups, 20);
         assert_eq!(config.exporter.performance.max_concurrent_watermarks, 100);
         assert_eq!(config.exporter.performance.client_recycle_interval, 0);

--- a/src/kafka/admin.rs
+++ b/src/kafka/admin.rs
@@ -12,6 +12,7 @@
 
 use crate::error::{KlagError, Result};
 use crate::kafka::client::TopicPartition;
+use crate::retry::full_jitter_backoff;
 use rdkafka::admin::AdminClient;
 use rdkafka::bindings::{
     rd_kafka_AdminOptions_destroy, rd_kafka_AdminOptions_new,
@@ -27,20 +28,21 @@ use rdkafka::bindings::{
     rd_kafka_MemberDescription_assignment, rd_kafka_MemberDescription_client_id,
     rd_kafka_MemberDescription_consumer_id, rd_kafka_MemberDescription_host, rd_kafka_OffsetSpec_t,
     rd_kafka_admin_op_t, rd_kafka_consumer_group_state_name, rd_kafka_err2name,
-    rd_kafka_error_code, rd_kafka_error_string, rd_kafka_event_DescribeConsumerGroups_result,
-    rd_kafka_event_ListConsumerGroupOffsets_result, rd_kafka_event_ListOffsets_result,
-    rd_kafka_event_destroy, rd_kafka_event_error, rd_kafka_event_error_string, rd_kafka_event_t,
-    rd_kafka_event_type, rd_kafka_group_result_error, rd_kafka_group_result_name,
-    rd_kafka_group_result_partitions, rd_kafka_queue_destroy, rd_kafka_queue_new,
-    rd_kafka_queue_poll, rd_kafka_queue_t, rd_kafka_resp_err_t, rd_kafka_t,
-    rd_kafka_topic_partition_list_add, rd_kafka_topic_partition_list_destroy,
-    rd_kafka_topic_partition_list_new, rd_kafka_topic_partition_list_t,
-    RD_KAFKA_EVENT_DESCRIBECONSUMERGROUPS_RESULT, RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT,
-    RD_KAFKA_EVENT_LISTOFFSETS_RESULT,
+    rd_kafka_error_code, rd_kafka_error_is_retriable, rd_kafka_error_string,
+    rd_kafka_event_DescribeConsumerGroups_result, rd_kafka_event_ListConsumerGroupOffsets_result,
+    rd_kafka_event_ListOffsets_result, rd_kafka_event_destroy, rd_kafka_event_error,
+    rd_kafka_event_error_string, rd_kafka_event_t, rd_kafka_event_type,
+    rd_kafka_group_result_error, rd_kafka_group_result_name, rd_kafka_group_result_partitions,
+    rd_kafka_queue_destroy, rd_kafka_queue_new, rd_kafka_queue_poll, rd_kafka_queue_t,
+    rd_kafka_resp_err_t, rd_kafka_t, rd_kafka_topic_partition_list_add,
+    rd_kafka_topic_partition_list_destroy, rd_kafka_topic_partition_list_new,
+    rd_kafka_topic_partition_list_t, RD_KAFKA_EVENT_DESCRIBECONSUMERGROUPS_RESULT,
+    RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT, RD_KAFKA_EVENT_LISTOFFSETS_RESULT,
 };
 use rdkafka::client::DefaultClientContext;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString};
+use std::fmt;
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Arc;
@@ -98,6 +100,82 @@ pub fn errstr_to_string(buf: &[c_char]) -> String {
 /// Build a C cstring from a Rust &str, returning a `KlagError` on embedded NULs.
 pub fn cstring_or_err(s: &str) -> Result<CString> {
     CString::new(s).map_err(|e| KlagError::Admin(format!("Invalid C string '{s}': {e}")))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AdminRequestError {
+    operation: &'static str,
+    code: Option<rd_kafka_resp_err_t>,
+    message: String,
+    retriable: bool,
+}
+
+impl AdminRequestError {
+    fn new(
+        operation: &'static str,
+        code: Option<rd_kafka_resp_err_t>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            operation,
+            code,
+            message: message.into(),
+            retriable: code.is_some_and(is_retriable_admin_code),
+        }
+    }
+
+    fn from_group_error(
+        operation: &'static str,
+        error: *const rdkafka::bindings::rd_kafka_error_t,
+    ) -> Self {
+        // SAFETY: callers obtain `error` from a live Admin API result and keep
+        // its event alive for this entire conversion.
+        let code = unsafe { rd_kafka_error_code(error) };
+        let message = unsafe { ptr_to_string(rd_kafka_error_string(error)) };
+        let native_retriable = unsafe { rd_kafka_error_is_retriable(error) != 0 };
+        let mut converted = Self::new(operation, Some(code), message);
+        // Some Admin API result constructors copy only the code and message,
+        // dropping librdkafka's retriable flag. Keep the native flag when it
+        // survives, and otherwise use the documented code allow-list below.
+        converted.retriable |= native_retriable;
+        converted
+    }
+
+    pub(crate) fn task(operation: &'static str, message: impl Into<String>) -> Self {
+        Self::new(operation, None, message)
+    }
+
+    pub(crate) const fn is_retriable(&self) -> bool {
+        self.retriable
+    }
+}
+
+impl fmt::Display for AdminRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.code {
+            Some(code) => write!(f, "{}: {} ({code:?})", self.operation, self.message),
+            None => write!(f, "{}: {}", self.operation, self.message),
+        }
+    }
+}
+
+/// Conservative allow-list for transient Admin API errors.
+/// Anything not in this list is considered non-retriable.
+const fn is_retriable_admin_code(code: rd_kafka_resp_err_t) -> bool {
+    matches!(
+        code,
+        rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TRANSPORT
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TIMED_OUT
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TIMED_OUT_QUEUE
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__WAIT_COORD
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_BROKER_NOT_AVAILABLE
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NETWORK_EXCEPTION
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE
+            | rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NOT_COORDINATOR
+    )
 }
 
 /// Keep the admin client alive for the duration of an FFI call. This type is
@@ -346,105 +424,146 @@ pub async fn describe_consumer_groups_batched(
     chunk_size: usize,
     parse_assignments: bool,
     max_concurrent_chunks: usize,
+    max_retries: usize,
 ) -> Result<Vec<BatchedGroupDescription>> {
     if group_ids.is_empty() {
         return Ok(Vec::new());
     }
     let chunk_size = chunk_size.max(1);
     let max_concurrent = max_concurrent_chunks.max(1);
-
-    // Own the strings so each spawn_blocking closure can take them without
-    // borrowing from the caller's slice.
-    let chunks: Vec<Vec<String>> = group_ids
-        .chunks(chunk_size)
-        .map(|c| c.iter().map(std::string::ToString::to_string).collect())
-        .collect();
-
-    // Each chunk carries enough identifying context to make partial-
-    // failure warnings actionable: chunk index, chunk size, and the
-    // first / last group id in the chunk.
-    #[derive(Clone)]
-    struct ChunkMeta {
-        index: usize,
-        size: usize,
-        first: String,
-        last: String,
-    }
-
     let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
-    let mut handles = Vec::with_capacity(chunks.len());
-
-    for (index, chunk) in chunks.into_iter().enumerate() {
-        let meta = ChunkMeta {
-            index,
-            size: chunk.len(),
-            first: chunk.first().cloned().unwrap_or_default(),
-            last: chunk.last().cloned().unwrap_or_default(),
-        };
-        let permit = Arc::clone(&semaphore);
-        let admin = Arc::clone(&admin);
-        handles.push(tokio::spawn(async move {
-            let _permit: tokio::sync::OwnedSemaphorePermit =
-                permit.acquire_owned().await.expect("semaphore closed");
-            let result = tokio::task::spawn_blocking(move || {
-                let refs: Vec<&str> = chunk.iter().map(std::string::String::as_str).collect();
-                describe_consumer_groups_one_chunk(&admin, &refs, timeout, parse_assignments)
-            })
-            .await;
-            (meta, result)
-        }));
-    }
-
-    let results = futures::future::join_all(handles).await;
     let mut out = Vec::with_capacity(group_ids.len());
-    for r in results {
-        match r {
-            Ok((_meta, Ok(Ok(mut part)))) => out.append(&mut part),
-            Ok((meta, Ok(Err(e)))) => {
+    let mut pending: Vec<String> = group_ids.iter().map(|group| (*group).to_string()).collect();
+    let max_attempts = max_retries.saturating_add(1);
+
+    for attempt in 1..=max_attempts {
+        if attempt > 1 {
+            let retry_number = attempt - 1;
+            let delay = full_jitter_backoff(retry_number);
+            debug!(
+                failed_groups = pending.len(),
+                attempt = attempt,
+                max_attempts = max_attempts,
+                backoff_ms = delay.as_millis(),
+                "Retrying failed DescribeConsumerGroups requests"
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        // Own each chunk so its blocking task cannot borrow the caller's
+        // group-id slice. Retried rounds contain only groups that failed in
+        // the previous round.
+        let chunks: Vec<Vec<String>> = pending.chunks(chunk_size).map(<[String]>::to_vec).collect();
+        let mut calls = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            let permit = Arc::clone(&semaphore);
+            let admin = Arc::clone(&admin);
+            calls.push(async move {
+                let _permit = permit.acquire_owned().await.expect("semaphore closed");
+                let requested = chunk.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    let refs: Vec<&str> = chunk.iter().map(std::string::String::as_str).collect();
+                    describe_consumer_groups_one_chunk(&admin, &refs, timeout, parse_assignments)
+                })
+                .await;
+                (requested, result)
+            });
+        }
+
+        let results = futures::future::join_all(calls).await;
+        let mut retryable_failures = Vec::new();
+
+        for (requested, result) in results {
+            let response = match result {
+                Ok(Ok(response)) => response,
+                Ok(Err(error)) => DescribeGroupsResponse::failed(requested, error),
+                Err(error) => {
+                    let mode = if error.is_cancelled() {
+                        "cancelled"
+                    } else if error.is_panic() {
+                        "panicked"
+                    } else {
+                        "failed"
+                    };
+                    let error = AdminRequestError::task(
+                        "DescribeConsumerGroups",
+                        format!("blocking task {mode}: {error}"),
+                    );
+                    DescribeGroupsResponse::failed(requested, error)
+                }
+            };
+
+            let partitioned = response.partition_for_retry(attempt < max_attempts);
+            out.extend(partitioned.descriptions);
+            retryable_failures.extend(partitioned.retryable_group_ids);
+            for failure in partitioned.terminal_failures {
                 warn!(
-                    error = %e,
-                    chunk_index = meta.index,
-                    chunk_size = meta.size,
-                    first_group = %meta.first,
-                    last_group = %meta.last,
-                    "DescribeConsumerGroups chunk failed"
+                    group = %failure.group_id,
+                    error = %failure.error,
+                    attempts = attempt,
+                    retriable = failure.error.is_retriable(),
+                    "DescribeConsumerGroups per-group error"
                 );
-            }
-            Ok((meta, Err(e))) => {
-                // A JoinError from spawn_blocking. Distinguish cancellation
-                // from panic so operators don't chase a bug that wasn't one.
-                let mode = if e.is_cancelled() {
-                    "cancelled"
-                } else if e.is_panic() {
-                    "panicked"
-                } else {
-                    "failed"
-                };
-                warn!(
-                    error = %e,
-                    chunk_index = meta.index,
-                    chunk_size = meta.size,
-                    first_group = %meta.first,
-                    last_group = %meta.last,
-                    "DescribeConsumerGroups chunk task {}",
-                    mode
-                );
-            }
-            Err(e) => {
-                // Outer tokio::spawn JoinError. Chunk meta is not available
-                // here because the outer task owned it — log what we have.
-                let mode = if e.is_cancelled() {
-                    "cancelled"
-                } else if e.is_panic() {
-                    "panicked"
-                } else {
-                    "failed"
-                };
-                warn!(error = %e, "DescribeConsumerGroups outer task {}", mode);
             }
         }
+
+        if retryable_failures.is_empty() {
+            break;
+        }
+        pending = retryable_failures;
     }
+
     Ok(out)
+}
+
+#[derive(Debug)]
+struct GroupRequestFailure {
+    group_id: String,
+    error: AdminRequestError,
+}
+
+#[derive(Debug)]
+struct DescribeGroupsResponse {
+    descriptions: Vec<BatchedGroupDescription>,
+    failures: Vec<GroupRequestFailure>,
+}
+
+impl DescribeGroupsResponse {
+    fn failed(group_ids: Vec<String>, error: AdminRequestError) -> Self {
+        Self {
+            descriptions: Vec::new(),
+            failures: group_ids
+                .into_iter()
+                .map(|group_id| GroupRequestFailure {
+                    group_id,
+                    error: error.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    fn partition_for_retry(self, can_retry: bool) -> DescribeRetryPartition {
+        let mut retryable_group_ids = Vec::new();
+        let mut terminal_failures = Vec::new();
+        for failure in self.failures {
+            if can_retry && failure.error.is_retriable() {
+                retryable_group_ids.push(failure.group_id);
+            } else {
+                terminal_failures.push(failure);
+            }
+        }
+        DescribeRetryPartition {
+            descriptions: self.descriptions,
+            retryable_group_ids,
+            terminal_failures,
+        }
+    }
+}
+
+struct DescribeRetryPartition {
+    descriptions: Vec<BatchedGroupDescription>,
+    retryable_group_ids: Vec<String>,
+    terminal_failures: Vec<GroupRequestFailure>,
 }
 
 fn describe_consumer_groups_one_chunk(
@@ -452,7 +571,7 @@ fn describe_consumer_groups_one_chunk(
     group_ids: &[&str],
     timeout: Duration,
     parse_assignments: bool,
-) -> Result<Vec<BatchedGroupDescription>> {
+) -> std::result::Result<DescribeGroupsResponse, AdminRequestError> {
     let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
     let rk = admin_native_ptr(admin);
 
@@ -461,7 +580,8 @@ fn describe_consumer_groups_one_chunk(
     let cstrings: Vec<CString> = group_ids
         .iter()
         .map(|g| cstring_or_err(g))
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>>>()
+        .map_err(|error| AdminRequestError::task("DescribeConsumerGroups", error.to_string()))?;
     let mut ptrs: Vec<*const c_char> = cstrings.iter().map(|c| c.as_ptr()).collect();
 
     struct Cleanup {
@@ -491,8 +611,9 @@ fn describe_consumer_groups_one_chunk(
             rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_DESCRIBECONSUMERGROUPS,
         );
         if options.is_null() {
-            return Err(KlagError::Admin(
-                "Failed to create AdminOptions (DescribeConsumerGroups)".into(),
+            return Err(AdminRequestError::task(
+                "DescribeConsumerGroups",
+                "failed to create AdminOptions",
             ));
         }
         let mut cleanup = Cleanup {
@@ -509,16 +630,21 @@ fn describe_consumer_groups_one_chunk(
             errstr_buf.len(),
         );
         if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-            return Err(KlagError::Admin(format!(
-                "Failed to set request timeout (DescribeConsumerGroups): {}",
-                errstr_to_string(&errstr_buf)
-            )));
+            return Err(AdminRequestError::new(
+                "DescribeConsumerGroups",
+                Some(err),
+                format!(
+                    "failed to set request timeout: {}",
+                    errstr_to_string(&errstr_buf)
+                ),
+            ));
         }
 
         let queue = rd_kafka_queue_new(rk);
         if queue.is_null() {
-            return Err(KlagError::Admin(
-                "Failed to create queue (DescribeConsumerGroups)".into(),
+            return Err(AdminRequestError::task(
+                "DescribeConsumerGroups",
+                "failed to create queue",
             ));
         }
         cleanup.queue = queue;
@@ -527,15 +653,20 @@ fn describe_consumer_groups_one_chunk(
 
         let event = rd_kafka_queue_poll(queue, timeout_ms);
         if event.is_null() {
-            return Err(KlagError::Admin("DescribeConsumerGroups timed out".into()));
+            return Err(AdminRequestError::new(
+                "DescribeConsumerGroups",
+                Some(rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TIMED_OUT),
+                "timed out waiting for response",
+            ));
         }
         cleanup.event = event;
 
         let event_type = rd_kafka_event_type(event);
         if event_type != RD_KAFKA_EVENT_DESCRIBECONSUMERGROUPS_RESULT {
-            return Err(KlagError::Admin(format!(
-                "Unexpected event type (DescribeConsumerGroups): {event_type}"
-            )));
+            return Err(AdminRequestError::task(
+                "DescribeConsumerGroups",
+                format!("unexpected event type: {event_type}"),
+            ));
         }
 
         let resp_err = rd_kafka_event_error(event);
@@ -546,34 +677,45 @@ fn describe_consumer_groups_one_chunk(
             } else {
                 CStr::from_ptr(err_cstr).to_string_lossy().to_string()
             };
-            return Err(KlagError::Admin(format!(
-                "DescribeConsumerGroups failed: {err_msg}"
-            )));
+            return Err(AdminRequestError::new(
+                "DescribeConsumerGroups",
+                Some(resp_err),
+                format!("request failed: {err_msg}"),
+            ));
         }
 
         let result = rd_kafka_event_DescribeConsumerGroups_result(event);
         if result.is_null() {
-            return Err(KlagError::Admin(
-                "DescribeConsumerGroups result is null".into(),
+            return Err(AdminRequestError::task(
+                "DescribeConsumerGroups",
+                "result is null",
             ));
         }
 
         let mut n: usize = 0;
         let groups_ptr = rd_kafka_DescribeConsumerGroups_result_groups(result, &raw mut n);
-        let mut out = Vec::with_capacity(n);
-        if groups_ptr.is_null() || n == 0 {
-            return Ok(out);
-        }
+        let mut descriptions = Vec::with_capacity(n);
+        let mut failures = Vec::new();
+        let mut returned_groups = HashSet::with_capacity(n);
 
+        if groups_ptr.is_null() {
+            n = 0;
+        }
         for i in 0..n {
             let grp = *groups_ptr.add(i);
             let group_id = ptr_to_string(rd_kafka_ConsumerGroupDescription_group_id(grp));
+            returned_groups.insert(group_id.clone());
             let grp_err = rd_kafka_ConsumerGroupDescription_error(grp);
             if !grp_err.is_null() {
                 let code = rd_kafka_error_code(grp_err);
                 if code != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-                    let msg = ptr_to_string(rd_kafka_error_string(grp_err));
-                    warn!(group = %group_id, error = %msg, "DescribeConsumerGroups per-group error");
+                    failures.push(GroupRequestFailure {
+                        group_id,
+                        error: AdminRequestError::from_group_error(
+                            "DescribeConsumerGroups",
+                            grp_err,
+                        ),
+                    });
                     continue;
                 }
             }
@@ -619,19 +761,38 @@ fn describe_consumer_groups_one_chunk(
                 });
             }
 
-            out.push(BatchedGroupDescription {
+            descriptions.push(BatchedGroupDescription {
                 group_id,
                 state: state_str,
                 members,
             });
         }
 
+        // A successful event should contain one result per requested group.
+        // Preserve a missing result as an explicit, non-retriable failure
+        // instead of silently turning it into absent group data.
+        for group_id in group_ids {
+            if !returned_groups.contains(*group_id) {
+                failures.push(GroupRequestFailure {
+                    group_id: (*group_id).to_string(),
+                    error: AdminRequestError::task(
+                        "DescribeConsumerGroups",
+                        "response omitted the requested group",
+                    ),
+                });
+            }
+        }
+
         debug!(
             requested = group_ids.len(),
-            returned = out.len(),
+            returned = descriptions.len(),
+            failed = failures.len(),
             "Batched DescribeConsumerGroups complete"
         );
-        Ok(out)
+        Ok(DescribeGroupsResponse {
+            descriptions,
+            failures,
+        })
     }
 }
 
@@ -649,36 +810,61 @@ unsafe fn ptr_to_string(p: *const c_char) -> String {
 /// (much smaller) response.
 ///
 /// Chunks groups into sub-calls of at most `chunk_size` groups each.
-pub fn list_consumer_group_offsets_batched(
+pub(crate) fn list_consumer_group_offsets_batched(
     admin: &AdminClient<DefaultClientContext>,
     group_ids: &[&str],
     timeout: Duration,
     chunk_size: usize,
-) -> Result<HashMap<String, HashMap<TopicPartition, i64>>> {
+) -> std::result::Result<GroupOffsetsResponse, AdminRequestError> {
     if group_ids.is_empty() {
-        return Ok(HashMap::new());
+        return Ok(GroupOffsetsResponse::default());
     }
     let chunk_size = chunk_size.max(1);
-    let mut out = HashMap::with_capacity(group_ids.len());
+    let mut response = GroupOffsetsResponse {
+        offsets: HashMap::with_capacity(group_ids.len()),
+        failures: Vec::new(),
+    };
     for chunk in group_ids.chunks(chunk_size) {
-        let part = list_consumer_group_offsets_one_chunk(admin, chunk, timeout)?;
-        out.extend(part);
+        let mut part = list_consumer_group_offsets_one_chunk(admin, chunk, timeout)?;
+        response.offsets.extend(part.offsets);
+        response.failures.append(&mut part.failures);
     }
-    Ok(out)
+    Ok(response)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GroupOffsetsResponse {
+    offsets: HashMap<String, HashMap<TopicPartition, i64>>,
+    failures: Vec<GroupRequestFailure>,
+}
+
+impl GroupOffsetsResponse {
+    /// Convert the response from the collector's current one-group-per-call
+    /// path into a retryable result. A successful empty offset map remains a
+    /// success; only an explicit group failure becomes `Err`.
+    pub(crate) fn into_single_group_result(
+        mut self,
+    ) -> std::result::Result<HashMap<String, HashMap<TopicPartition, i64>>, AdminRequestError> {
+        if let Some(failure) = self.failures.pop() {
+            return Err(failure.error);
+        }
+        Ok(self.offsets)
+    }
 }
 
 fn list_consumer_group_offsets_one_chunk(
     admin: &AdminClient<DefaultClientContext>,
     group_ids: &[&str],
     timeout: Duration,
-) -> Result<HashMap<String, HashMap<TopicPartition, i64>>> {
+) -> std::result::Result<GroupOffsetsResponse, AdminRequestError> {
     let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
     let rk = admin_native_ptr(admin);
 
     let cstrings: Vec<CString> = group_ids
         .iter()
         .map(|g| cstring_or_err(g))
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>>>()
+        .map_err(|error| AdminRequestError::task("ListConsumerGroupOffsets", error.to_string()))?;
 
     struct Cleanup {
         requests: Vec<*mut rd_kafka_ListConsumerGroupOffsets_t>,
@@ -721,8 +907,9 @@ fn list_consumer_group_offsets_one_chunk(
             // amplifier from the old per-group call path.
             let req = rd_kafka_ListConsumerGroupOffsets_new(c.as_ptr(), ptr::null_mut());
             if req.is_null() {
-                return Err(KlagError::Admin(
-                    "Failed to create ListConsumerGroupOffsets request".into(),
+                return Err(AdminRequestError::task(
+                    "ListConsumerGroupOffsets",
+                    "failed to create request",
                 ));
             }
             cleanup.requests.push(req);
@@ -733,8 +920,9 @@ fn list_consumer_group_offsets_one_chunk(
             rd_kafka_admin_op_t::RD_KAFKA_ADMIN_OP_LISTCONSUMERGROUPOFFSETS,
         );
         if options.is_null() {
-            return Err(KlagError::Admin(
-                "Failed to create AdminOptions (ListConsumerGroupOffsets)".into(),
+            return Err(AdminRequestError::task(
+                "ListConsumerGroupOffsets",
+                "failed to create AdminOptions",
             ));
         }
         cleanup.options = options;
@@ -747,16 +935,21 @@ fn list_consumer_group_offsets_one_chunk(
             errstr_buf.len(),
         );
         if err != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-            return Err(KlagError::Admin(format!(
-                "Failed to set request timeout (ListConsumerGroupOffsets batched): {}",
-                errstr_to_string(&errstr_buf)
-            )));
+            return Err(AdminRequestError::new(
+                "ListConsumerGroupOffsets",
+                Some(err),
+                format!(
+                    "failed to set request timeout: {}",
+                    errstr_to_string(&errstr_buf)
+                ),
+            ));
         }
 
         let queue = rd_kafka_queue_new(rk);
         if queue.is_null() {
-            return Err(KlagError::Admin(
-                "Failed to create queue (ListConsumerGroupOffsets batched)".into(),
+            return Err(AdminRequestError::task(
+                "ListConsumerGroupOffsets",
+                "failed to create queue",
             ));
         }
         cleanup.queue = queue;
@@ -771,17 +964,20 @@ fn list_consumer_group_offsets_one_chunk(
 
         let event = rd_kafka_queue_poll(queue, timeout_ms);
         if event.is_null() {
-            return Err(KlagError::Admin(
-                "ListConsumerGroupOffsets (batched) timed out".into(),
+            return Err(AdminRequestError::new(
+                "ListConsumerGroupOffsets",
+                Some(rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TIMED_OUT),
+                "timed out waiting for response",
             ));
         }
         cleanup.event = event;
 
         let event_type = rd_kafka_event_type(event);
         if event_type != RD_KAFKA_EVENT_LISTCONSUMERGROUPOFFSETS_RESULT {
-            return Err(KlagError::Admin(format!(
-                "Unexpected event type (ListConsumerGroupOffsets batched): {event_type}"
-            )));
+            return Err(AdminRequestError::task(
+                "ListConsumerGroupOffsets",
+                format!("unexpected event type: {event_type}"),
+            ));
         }
 
         let resp_err = rd_kafka_event_error(event);
@@ -792,38 +988,47 @@ fn list_consumer_group_offsets_one_chunk(
             } else {
                 CStr::from_ptr(err_cstr).to_string_lossy().to_string()
             };
-            return Err(KlagError::Admin(format!(
-                "ListConsumerGroupOffsets (batched) failed: {err_msg}"
-            )));
+            return Err(AdminRequestError::new(
+                "ListConsumerGroupOffsets",
+                Some(resp_err),
+                format!("request failed: {err_msg}"),
+            ));
         }
 
         let result = rd_kafka_event_ListConsumerGroupOffsets_result(event);
         if result.is_null() {
-            return Err(KlagError::Admin(
-                "ListConsumerGroupOffsets (batched) result is null".into(),
+            return Err(AdminRequestError::task(
+                "ListConsumerGroupOffsets",
+                "result is null",
             ));
         }
 
         let mut n_groups: usize = 0;
         let groups_ptr = rd_kafka_ListConsumerGroupOffsets_result_groups(result, &raw mut n_groups);
-        let mut out: HashMap<String, HashMap<TopicPartition, i64>> =
-            HashMap::with_capacity(n_groups);
-        if groups_ptr.is_null() || n_groups == 0 {
-            return Ok(out);
-        }
+        let mut offsets_by_group = HashMap::with_capacity(n_groups);
+        let mut failures = Vec::new();
+        let mut returned_groups = HashSet::with_capacity(n_groups);
 
+        if groups_ptr.is_null() {
+            n_groups = 0;
+        }
         for i in 0..n_groups {
             let group = *groups_ptr.add(i);
             let group_name = rd_kafka_group_result_name(group);
             let group_id = ptr_to_string(group_name);
+            returned_groups.insert(group_id.clone());
 
             let group_error = rd_kafka_group_result_error(group);
             if !group_error.is_null() {
                 let code = rd_kafka_error_code(group_error);
                 if code != rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
-                    let msg = ptr_to_string(rd_kafka_error_string(group_error));
-                    warn!(group = %group_id, error = %msg, "ListConsumerGroupOffsets per-group error");
-                    out.insert(group_id, HashMap::new());
+                    failures.push(GroupRequestFailure {
+                        group_id,
+                        error: AdminRequestError::from_group_error(
+                            "ListConsumerGroupOffsets",
+                            group_error,
+                        ),
+                    });
                     continue;
                 }
             }
@@ -844,15 +1049,33 @@ fn list_consumer_group_offsets_one_chunk(
                     }
                 }
             }
-            out.insert(group_id, offsets);
+            // An empty map here is a successful response with no committed
+            // offsets, distinct from the explicit failure path above.
+            offsets_by_group.insert(group_id, offsets);
+        }
+
+        for group_id in group_ids {
+            if !returned_groups.contains(*group_id) {
+                failures.push(GroupRequestFailure {
+                    group_id: (*group_id).to_string(),
+                    error: AdminRequestError::task(
+                        "ListConsumerGroupOffsets",
+                        "response omitted the requested group",
+                    ),
+                });
+            }
         }
 
         debug!(
             requested = group_ids.len(),
-            returned = out.len(),
+            returned = offsets_by_group.len(),
+            failed = failures.len(),
             "Batched ListConsumerGroupOffsets complete"
         );
-        Ok(out)
+        Ok(GroupOffsetsResponse {
+            offsets: offsets_by_group,
+            failures,
+        })
     }
 }
 
@@ -887,5 +1110,104 @@ mod tests {
         assert!(Arc::ptr_eq(&a, &b), "same topic must share the Arc");
         let c = interner.intern("bar");
         assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    #[test]
+    fn transient_group_admin_errors_are_retriable() {
+        assert!(is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TRANSPORT
+        ));
+        assert!(is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT
+        ));
+        assert!(is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE
+        ));
+        assert!(is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NOT_COORDINATOR
+        ));
+    }
+
+    #[test]
+    fn permanent_group_admin_errors_are_not_retriable() {
+        assert!(!is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__AUTHENTICATION
+        ));
+        assert!(!is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED
+        ));
+        assert!(!is_retriable_admin_code(
+            rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_INVALID_GROUP_ID
+        ));
+    }
+
+    #[test]
+    fn successful_empty_group_offsets_are_not_a_failure() {
+        let response = GroupOffsetsResponse {
+            offsets: HashMap::from([("group-a".to_string(), HashMap::new())]),
+            failures: Vec::new(),
+        };
+
+        let offsets = response.into_single_group_result().unwrap();
+        assert!(offsets.contains_key("group-a"));
+        assert!(offsets["group-a"].is_empty());
+    }
+
+    #[test]
+    fn explicit_group_offset_failure_is_preserved() {
+        let response = GroupOffsetsResponse {
+            offsets: HashMap::new(),
+            failures: vec![GroupRequestFailure {
+                group_id: "group-a".to_string(),
+                error: AdminRequestError::new(
+                    "ListConsumerGroupOffsets",
+                    Some(rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TRANSPORT),
+                    "transport failure",
+                ),
+            }],
+        };
+
+        let error = response.into_single_group_result().unwrap_err();
+        assert!(error.is_retriable());
+    }
+
+    #[test]
+    fn describe_retry_partition_selects_only_retriable_failures() {
+        let response = DescribeGroupsResponse {
+            descriptions: vec![BatchedGroupDescription {
+                group_id: "successful-group".to_string(),
+                state: "Stable".to_string(),
+                members: Vec::new(),
+            }],
+            failures: vec![
+                GroupRequestFailure {
+                    group_id: "transient-failure".to_string(),
+                    error: AdminRequestError::new(
+                        "DescribeConsumerGroups",
+                        Some(rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__TRANSPORT),
+                        "transport failure",
+                    ),
+                },
+                GroupRequestFailure {
+                    group_id: "permanent-failure".to_string(),
+                    error: AdminRequestError::new(
+                        "DescribeConsumerGroups",
+                        Some(rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED),
+                        "authorization failure",
+                    ),
+                },
+            ],
+        };
+
+        let partitioned = response.partition_for_retry(true);
+
+        assert_eq!(partitioned.descriptions.len(), 1);
+        assert_eq!(partitioned.descriptions[0].group_id, "successful-group");
+        assert_eq!(partitioned.retryable_group_ids, vec!["transient-failure"]);
+        assert_eq!(partitioned.terminal_failures.len(), 1);
+        assert_eq!(
+            partitioned.terminal_failures[0].group_id,
+            "permanent-failure"
+        );
     }
 }

--- a/src/kafka/client.rs
+++ b/src/kafka/client.rs
@@ -242,6 +242,7 @@ impl KafkaClient {
             100,
             parse_assignments,
             max_concurrent_chunks,
+            self.performance.group_fetch_retries,
         )
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod http;
 mod kafka;
 mod leadership;
 mod metrics;
+mod retry;
 
 use crate::cluster::ClusterManager;
 use crate::config::Config;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,170 @@
+use std::future::Future;
+use std::time::Duration;
+
+const BASE_BACKOFF_MS: u64 = 50;
+const MAX_BACKOFF_MS: u64 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetryStopReason {
+    NonRetriable,
+    Exhausted,
+}
+
+#[derive(Debug)]
+pub(crate) struct RetryFailure<E> {
+    pub error: E,
+    pub attempts: usize,
+    pub reason: RetryStopReason,
+}
+
+/// Execute an asynchronous operation once, then retry retriable failures up to
+/// `max_retries` additional times.
+pub(crate) async fn retry_with_backoff<T, E, Operation, OperationFuture, Retriable, Backoff>(
+    max_retries: usize,
+    mut operation: Operation,
+    is_retriable: Retriable,
+    mut backoff: Backoff,
+) -> std::result::Result<(T, usize), RetryFailure<E>>
+where
+    Operation: FnMut(usize) -> OperationFuture,
+    OperationFuture: Future<Output = std::result::Result<T, E>>,
+    Retriable: Fn(&E) -> bool,
+    Backoff: FnMut(usize) -> Duration,
+{
+    let max_attempts = max_retries.saturating_add(1);
+
+    for attempt in 1..=max_attempts {
+        match operation(attempt).await {
+            Ok(value) => return Ok((value, attempt)),
+            Err(error) => {
+                if !is_retriable(&error) {
+                    return Err(RetryFailure {
+                        error,
+                        attempts: attempt,
+                        reason: RetryStopReason::NonRetriable,
+                    });
+                }
+                if attempt == max_attempts {
+                    return Err(RetryFailure {
+                        error,
+                        attempts: attempt,
+                        reason: RetryStopReason::Exhausted,
+                    });
+                }
+
+                let retry_number = attempt;
+                let delay = backoff(retry_number);
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+
+    unreachable!("the retry loop always returns on its final attempt")
+}
+
+/// Full-jitter exponential backoff: retry 1 waits 0-50 ms, retry 2 waits
+/// 0-100 ms, and subsequent caps double up to 1 second.
+pub(crate) fn full_jitter_backoff(retry_number: usize) -> Duration {
+    let exponent = retry_number.saturating_sub(1).min(63) as u32;
+    let cap_ms = BASE_BACKOFF_MS
+        .saturating_mul(2_u64.saturating_pow(exponent))
+        .min(MAX_BACKOFF_MS);
+    Duration::from_millis(rand::random_range(0..=cap_ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn zero_retries_attempts_once() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_with_backoff(
+            0,
+            |_| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>("transient")
+            },
+            |_| true,
+            |_| Duration::ZERO,
+        )
+        .await;
+
+        let failure = result.unwrap_err();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(failure.attempts, 1);
+        assert_eq!(failure.reason, RetryStopReason::Exhausted);
+    }
+
+    #[tokio::test]
+    async fn retriable_failure_recovers_on_retry() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_with_backoff(
+            2,
+            |_| async {
+                let call = calls.fetch_add(1, Ordering::SeqCst);
+                if call == 0 {
+                    Err("transient")
+                } else {
+                    Ok("recovered")
+                }
+            },
+            |_| true,
+            |_| Duration::ZERO,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, ("recovered", 2));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn non_retriable_failure_stops_immediately() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_with_backoff(
+            3,
+            |_| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>("permanent")
+            },
+            |_| false,
+            |_| Duration::ZERO,
+        )
+        .await;
+
+        let failure = result.unwrap_err();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(failure.reason, RetryStopReason::NonRetriable);
+    }
+
+    #[tokio::test]
+    async fn retriable_failure_exhausts_configured_attempts() {
+        let calls = AtomicUsize::new(0);
+        let result = retry_with_backoff(
+            2,
+            |_| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>("transient")
+            },
+            |_| true,
+            |_| Duration::ZERO,
+        )
+        .await;
+
+        let failure = result.unwrap_err();
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(failure.attempts, 3);
+        assert_eq!(failure.reason, RetryStopReason::Exhausted);
+    }
+
+    #[test]
+    fn jitter_stays_within_exponential_cap() {
+        for _ in 0..100 {
+            assert!(full_jitter_backoff(1) <= Duration::from_millis(50));
+            assert!(full_jitter_backoff(2) <= Duration::from_millis(100));
+            assert!(full_jitter_backoff(10) <= Duration::from_secs(1));
+        }
+    }
+}

--- a/test-stack/klag-config.toml
+++ b/test-stack/klag-config.toml
@@ -42,6 +42,7 @@ max_concurrent_fetches = 5
 
 [exporter.performance]
 client_recycle_interval = 0  # disabled for small test cluster
+group_fetch_retries = 2      # exercise transient Admin API recovery in the test stack
 
 [exporter.otel]
 enabled = false


### PR DESCRIPTION
## Overview

This adds a new config field, `exporter.performance.group_fetch_retries`. When set to a value greater than 0, it configures the exporter to retry transient errors encountered when describing consumer groups or listing consumer group offsets. This config field is optional and defaults to 0, which preserves the existing behavior (no retries). Errors are considered retriable if the structured Admin API response indicates that they are _or_ if they fall into a specified list of known retriable error codes.

## Background/rationale

Since deploying klag-exporter a week or two ago (loving it so far!) I've noticed a small but consistent number of runtime errors during its export cycles. These manifest as error logs with the following message: `Admin API error: ListConsumerGroupOffsets (batched) failed: Failed while waiting for response from broker: Local: Broker transport failure` and whenever they occur, the metrics for the affected CGs drop to 0 for that cycle. Not the end of the world, it usually resolves by the next cycle, but it can lead to flappy alerts. On our cluster with ~2k total consumer groups, we see drops in successfully-tracked CGs ranging from 1-300 in any given cycle. Sometimes there are no errors, but usually there's at least a few.

I've tried fiddling with a number of the connection/performance settings on klag-exporter, and none of them improve the situation. So this change is my attempt to make klag-exporter a little more resilient to transient network errors, by introducing the (optional!) ability to retry group-level API requests.

## Implementation

Retries in `DescribeConsumerGroups` are implemented so that only the group IDs that failed (with retriable errors) are retried. Successful results are retained until all retries are exhausted or all groups have succeeded. 

`ListConsumerGroupOffsets` isn't batched, so it's wrapped in a `retry_with_backoff` helper. Retries still respect the concurrency limit, and the wait period during a backoff does not hold the concurrency permit.

Retry loops themselves use exponential backoff with an initial cap of 50ms and a max backoff of 1s.

## Testing

Updated/added unit tests to cover the important changes in behavior, particularly around what counts as retriable and what doesn't.

In addition, added an integration test with a mocked Kafka cluster to verify the retry behavior for `OffsetCollector` end to end.

Confirmed the local docker compose test stack ran as expected under current configuration and with retries enabled.

Lastly (only did this locally) modified the docker compose stack to include [Toxiproxy](https://github.com/Shopify/toxiproxy) to simulate a temporarily flaky connection, and verified that without retries the exporter would exclude consumer groups from its metrics export, but with retries enabled the flakes would resolve and an export cycle could still include metrics for all topics/CGs.