### PR TITLE
chore: release v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/softwaremill/klag-exporter/compare/v0.1.27...v0.1.28) - 2026-08-26
+
+### Added
+
+- Configurable retries for transient group fetch errors ([#102](https://github.com/softwaremill/klag-exporter/pull/102))
+
+### Other
+
+- Merge pull request #106 from softwaremill/release-plz-2026-08-25T11-59-39Z
+- Merge remote-tracking branch 'origin/main' into pr-101
+
 ## [0.1.27](https://github.com/softwaremill/klag-exporter/compare/v0.1.26...v0.1.27) - 2026-08-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "klag-exporter"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1263,7 +1263,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prometheus",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rdkafka",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klag-exporter"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 description = "High-performance Kafka consumer group lag exporter with offset and time lag metrics"
 authors = ["Krzysztof Grajek"]

--- a/helm/klag-exporter/Chart.yaml
+++ b/helm/klag-exporter/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: "0.1.27"
+version: "0.1.28"
 
-appVersion: "0.1.27"
+appVersion: "0.1.28"

--- a/helm/klag-exporter/values.yaml
+++ b/helm/klag-exporter/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/softwaremill/klag-exporter
   pullPolicy: IfNotPresent
-  tag: "0.1.27"
+  tag: "0.1.28"
 
 imagePullSecrets: []
 # This is to override the chart name.


### PR DESCRIPTION



## 🤖 New release

* `klag-exporter`: 0.1.27 -> 0.1.28

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.28](https://github.com/softwaremill/klag-exporter/compare/v0.1.27...v0.1.28) - 2026-08-26

### Added

- Configurable retries for transient group fetch errors ([#102](https://github.com/softwaremill/klag-exporter/pull/102))

### Other

- Merge pull request #106 from softwaremill/release-plz-2026-08-25T11-59-39Z
- Merge remote-tracking branch 'origin/main' into pr-101
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).